### PR TITLE
Allow converting an `Identity` to a FROST `Identifier`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/iron-fish/ironfish-frost"
 [dependencies]
 ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
 rand_core = "0.6.4"
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", features = ["frost", "frost-rerandomized"] }
 x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub mod participant;
+
+use reddsa::frost::redjubjub as frost;


### PR DESCRIPTION
Code to create a FROST-compatible identifier from a Iron Fish MultiSig identity