### PR TITLE
Add functions to encrypt data to multiple participants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,13 @@ repository = "https://github.com/iron-fish/ironfish-frost"
 
 [dependencies]
 blake3 = "1.5.0"
+chacha20 = "0.9.1"
+chacha20poly1305 = "0.10.1"
 ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", features = ["frost", "frost-rerandomized"] }
-x25519-dalek = { version = "2.0.0", features = ["static_secrets"] }
+x25519-dalek = { version = "2.0.0", features = ["reusable_secrets", "static_secrets"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub mod multienc;
 pub mod nonces;
 pub mod participant;
 

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::participant::Identity;
+use crate::participant::Secret;
+use chacha20::cipher::KeyIvInit;
+use chacha20::cipher::StreamCipher;
+use chacha20::ChaCha20;
+use chacha20poly1305::aead::Aead;
+use chacha20poly1305::ChaCha20Poly1305;
+use chacha20poly1305::Error;
+use chacha20poly1305::KeyInit;
+use chacha20poly1305::Nonce;
+use rand_core::CryptoRng;
+use rand_core::RngCore;
+use std::borrow::Borrow;
+use x25519_dalek::PublicKey;
+use x25519_dalek::ReusableSecret;
+
+pub const KEY_SIZE: usize = 32;
+pub type EncryptedKey = [u8; KEY_SIZE];
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct MultiRecipientBlob<Keys, Cipher>
+where
+    Keys: AsRef<[EncryptedKey]>,
+    Cipher: AsRef<[u8]>,
+{
+    pub agreement_key: PublicKey,
+    pub encrypted_keys: Keys,
+    pub ciphertext: Cipher,
+}
+
+/// Encrypt arbitrary `data` once for multiple participants.
+///
+/// The data can be decrypted by each participant using [`decrypt`].
+pub fn encrypt<I, R>(
+    data: &[u8],
+    recipients: &[I],
+    mut csrng: R,
+) -> MultiRecipientBlob<Vec<EncryptedKey>, Vec<u8>>
+where
+    I: Borrow<Identity>,
+    R: RngCore + CryptoRng,
+{
+    // Use a zero nonce for all encryptions below. This is safe because each encryption key is
+    // ephemeral and used exactly once, so no (key, nonce) reuse ever happens.
+    let nonce = Nonce::default();
+
+    // Generate a random encryption key and encrypt the data with it using ChaCha20Poly1305
+    let encryption_key = ChaCha20Poly1305::generate_key(&mut csrng);
+    let cipher = ChaCha20Poly1305::new(&encryption_key);
+    let ciphertext = cipher.encrypt(&nonce, data).expect("encryption failed");
+
+    // Encrypt the encryption key for each recipient using X25519 + ChaCha20.
+    //
+    // Here we are using an unauthenticated cipher because we rely on the integrity provided by
+    // ChaCha20Poly1305 on the data. If an encrypted key is tampered, the recipient won't be able
+    // to correctly recover the data using ChaCha20Poly1305, and so they can detect the tampering.
+    let agreement_secret = ReusableSecret::random_from_rng(csrng);
+    let agreement_key = PublicKey::from(&agreement_secret);
+    let encrypted_keys = recipients
+        .iter()
+        .map(|id| {
+            let recipient_key = id.borrow().encryption_key();
+            let shared_secret = agreement_secret.diffie_hellman(recipient_key).to_bytes();
+            let mut cipher = ChaCha20::new((&shared_secret).into(), (&nonce).into());
+            let mut encrypted_key = encryption_key;
+
+            cipher.apply_keystream(&mut encrypted_key);
+            encrypted_key.into()
+        })
+        .collect();
+
+    MultiRecipientBlob {
+        agreement_key,
+        encrypted_keys,
+        ciphertext,
+    }
+}
+
+/// Decrypt data produced by [`encrypt`] using one participant secret.
+pub fn decrypt<Keys, Cipher>(
+    secret: &Secret,
+    blob: &MultiRecipientBlob<Keys, Cipher>,
+) -> Result<Vec<u8>, Error>
+where
+    Keys: AsRef<[EncryptedKey]>,
+    Cipher: AsRef<[u8]>,
+{
+    let nonce = Nonce::default();
+    let shared_secret = secret
+        .decryption_key()
+        .diffie_hellman(&blob.agreement_key)
+        .to_bytes();
+
+    // Try to decrypt each encryption key one by one, and use them to attempt to decrypt the data,
+    // until the data is recovered.
+    blob.encrypted_keys
+        .as_ref()
+        .iter()
+        .filter_map(|encrypted_key| {
+            // Decrypt the encryption key with X25519 + ChaCha20. This will always succeed, even if
+            // the encryption key was not for this participant (in which case, it will result in
+            // random bytes).
+            let mut encryption_key = *encrypted_key;
+            let mut cipher = ChaCha20::new((&shared_secret).into(), (&nonce).into());
+            cipher.apply_keystream(&mut encryption_key);
+
+            // Decrypt the data with ChaCha20Poly1305. This will fail if the encryption key was not
+            // for this participant (or if the encryption key was tampered).
+            let cipher = ChaCha20Poly1305::new((&encryption_key).into());
+            cipher.decrypt(&nonce, blob.ciphertext.as_ref()).ok()
+        })
+        .next()
+        .ok_or(Error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decrypt;
+    use super::encrypt;
+    use super::KEY_SIZE;
+    use crate::participant::Secret;
+    use chacha20poly1305::Error;
+    use rand::thread_rng;
+
+    #[test]
+    fn round_trip() {
+        let plaintext = b"hello";
+
+        let secret1 = Secret::random(thread_rng());
+        let secret2 = Secret::random(thread_rng());
+        let secret3 = Secret::random(thread_rng());
+        let id1 = secret1.to_identity();
+        let id2 = secret2.to_identity();
+
+        let blob = encrypt(plaintext, &[id1, id2], thread_rng());
+
+        assert_eq!(decrypt(&secret1, &blob), Ok(plaintext.to_vec()));
+        assert_eq!(decrypt(&secret2, &blob), Ok(plaintext.to_vec()));
+        assert_eq!(decrypt(&secret3, &blob), Err(Error));
+    }
+
+    #[test]
+    fn tampering() {
+        let plaintext = b"hello";
+
+        let secret1 = Secret::random(thread_rng());
+        let secret2 = Secret::random(thread_rng());
+        let id1 = secret1.to_identity();
+        let id2 = secret2.to_identity();
+
+        let blob = encrypt(plaintext, &[id1, id2], thread_rng());
+
+        assert_eq!(decrypt(&secret1, &blob), Ok(plaintext.to_vec()));
+        assert_eq!(decrypt(&secret2, &blob), Ok(plaintext.to_vec()));
+
+        // Altering the first encrypted key should be detected using `secret1`
+        for i in 0..KEY_SIZE {
+            let mut tampered_blob = blob.clone();
+            tampered_blob.encrypted_keys[0][i] ^= 0xff;
+            assert_eq!(decrypt(&secret1, &tampered_blob), Err(Error));
+            assert_eq!(decrypt(&secret2, &tampered_blob), Ok(plaintext.to_vec()));
+        }
+
+        // Altering the second encrypted key should be detected using `secret1`
+        for i in 0..KEY_SIZE {
+            let mut tampered_blob = blob.clone();
+            tampered_blob.encrypted_keys[1][i] ^= 0xff;
+            assert_eq!(decrypt(&secret1, &tampered_blob), Ok(plaintext.to_vec()));
+            assert_eq!(decrypt(&secret2, &tampered_blob), Err(Error));
+        }
+
+        // Altering the ciphertext should be detected using either `secret1` or `secret2`
+        for i in 0..plaintext.len() {
+            let mut tampered_blob = blob.clone();
+            tampered_blob.ciphertext[i] ^= 0xff;
+            assert_eq!(decrypt(&secret1, &tampered_blob), Err(Error));
+            assert_eq!(decrypt(&secret2, &tampered_blob), Err(Error));
+        }
+    }
+}


### PR DESCRIPTION
This allows encrypting a single message for multiple participants in a compact way.

Given a list of participants identities and a message:
- encrypts the message with a random encryption key (using ChaCha20-Poly1305)
- encrypts the random encryption key for each and every participant (using X25519-ChaCha20)

To save bytes, the nonce is set to a zero byte string for all encryptions. This is safe because each encryption key is randomly generated on the spot and used exactly once, so there is no (key, nonce) reuse.

The total output size is:

```
agreement_key_size + encryption_key_size * number_of_recipients + message_size + tag_size
= 32 bytes + 32 bytes * number_of_recipients + message_size + 16 bytes
= 48 bytes + 32 bytes * number_of_recipients + message_size
```