### PR TITLE
chore: reexport reddsa so we can use the types elsewhere

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,4 @@
 pub mod nonces;
 pub mod participant;
 
-use reddsa::frost::redjubjub as frost;
+pub use reddsa::frost::redjubjub as frost;


### PR DESCRIPTION
To be able to use the types of this dependency, we need to make it public