### PR TITLE
Pin the version of `reddsa`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
 once_cell = "1.8.0"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
-reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", features = ["frost", "frost-rerandomized"] }
+reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "311baf8865f6e21527d1f20750d8f2cf5c9e531a", features = ["frost", "frost-rerandomized"] }
 x25519-dalek = { version = "2.0.0", features = ["reusable_secrets", "static_secrets"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Pin `reddsa` to a specific commit to prevent unintentional breakage when backward-incompatble changes are made to it.