### PR TITLE
Minor improvements

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -2,45 +2,60 @@ use crate::frost::keys::PublicKeyPackage as FrostPublicKeyPackage;
 use crate::participant::Identity;
 use std::io;
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct PublicKeyPackage {
-    pub frost_public_key_package: FrostPublicKeyPackage,
-    pub identities: Vec<Identity>,
+    frost_public_key_package: FrostPublicKeyPackage,
+    identities: Vec<Identity>,
 }
 
 impl PublicKeyPackage {
-    pub fn write<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+    pub fn identities(&self) -> &[Identity] {
+        &self.identities[..]
+    }
+
+    pub fn frost_public_key_package(&self) -> &FrostPublicKeyPackage {
+        &self.frost_public_key_package
+    }
+
+    pub fn serialize(&self) -> io::Result<Vec<u8>> {
+        let mut s = Vec::new();
+        self.serialize_into(&mut s)?;
+        Ok(s)
+    }
+
+    pub fn serialize_into<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
         let public_key_package = self
             .frost_public_key_package
             .serialize()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         let public_key_package_len = u32::try_from(public_key_package.len())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
             .to_le_bytes();
         writer.write_all(&public_key_package_len)?;
         writer.write_all(&public_key_package)?;
 
         let identities_len = u32::try_from(self.identities.len())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
             .to_le_bytes();
         writer.write_all(&identities_len)?;
         for identity in &self.identities {
             let identity_bytes = identity.serialize();
             writer.write_all(&identity_bytes)?
         }
+
         Ok(())
     }
 
-    pub fn read<R: io::Read>(mut reader: R) -> io::Result<Self> {
+    pub fn deserialize_from<R: io::Read>(mut reader: R) -> io::Result<Self> {
         let mut public_key_package_len = [0u8; 4];
         reader.read_exact(&mut public_key_package_len)?;
         let public_key_package_len = u32::from_le_bytes(public_key_package_len) as usize;
 
-        let mut public_key_package_vec = vec![0u8; public_key_package_len];
-        reader.read_exact(&mut public_key_package_vec)?;
-
-        let public_key_package = FrostPublicKeyPackage::deserialize(&public_key_package_vec)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        let mut frost_public_key_package = vec![0u8; public_key_package_len];
+        reader.read_exact(&mut frost_public_key_package)?;
+        let frost_public_key_package =
+            FrostPublicKeyPackage::deserialize(&frost_public_key_package)
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
         let mut identities_len = [0u8; 4];
         reader.read_exact(&mut identities_len)?;
@@ -52,7 +67,7 @@ impl PublicKeyPackage {
         }
 
         Ok(PublicKeyPackage {
-            frost_public_key_package: public_key_package,
+            frost_public_key_package,
             identities,
         })
     }

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -237,7 +237,7 @@ impl Identity {
         let mut verification_key = [0u8; VERIFICATION_KEY_LEN];
         reader.read_exact(&mut verification_key)?;
         let verification_key = VerifyingKey::from_bytes(&verification_key)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
         let mut encryption_key = [0u8; ENCRYPTION_KEY_LEN];
         reader.read_exact(&mut encryption_key)?;
@@ -248,7 +248,7 @@ impl Identity {
         let signature = Signature::from(signature);
 
         Self::new(verification_key, encryption_key, signature)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
 }
 


### PR DESCRIPTION
- removed unnecessary conversions to `String`
- hid internal implementation details in favor of accessors by ref
- renamed `read`/`write` methods to `deserialize_from`/`serialize_into` for consistency