### PR TITLE
Add `PublicKeyPackage::verifying_key()`

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,4 +1,5 @@
 use crate::frost::keys::PublicKeyPackage as FrostPublicKeyPackage;
+use crate::frost::VerifyingKey;
 use crate::participant::Identity;
 use std::io;
 
@@ -11,6 +12,10 @@ pub struct PublicKeyPackage {
 impl PublicKeyPackage {
     pub fn identities(&self) -> &[Identity] {
         &self.identities[..]
+    }
+
+    pub fn verifying_key(&self) -> &VerifyingKey {
+        self.frost_public_key_package.verifying_key()
     }
 
     pub fn frost_public_key_package(&self) -> &FrostPublicKeyPackage {


### PR DESCRIPTION
Accessing the verifying key of a public key package is a common task, so it makes sense to have a method to do it directly.