### PR TITLE
Add `PublicKeyPackage::from_frost`

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -10,6 +10,17 @@ pub struct PublicKeyPackage {
 }
 
 impl PublicKeyPackage {
+    #[must_use]
+    pub fn from_frost<I>(frost_public_key_package: FrostPublicKeyPackage, identities: I) -> Self
+    where
+        I: IntoIterator<Item = Identity>,
+    {
+        Self {
+            frost_public_key_package,
+            identities: identities.into_iter().collect(),
+        }
+    }
+
     pub fn identities(&self) -> &[Identity] {
         &self.identities[..]
     }


### PR DESCRIPTION
This allows the construction of new `PublicKeyPackage` (necessary since the internal fields were made private in #14)