### PR TITLE
feat(frost): Add authentication methods

### DIFF
--- a/src/participant.rs
+++ b/src/participant.rs
@@ -256,7 +256,7 @@ impl Identity {
     }
 
     pub fn verify_data(&self, data: &[u8], signature: &Signature) -> Result<(), SignatureError> {
-        self.verification_key.verify(data, &signature)
+        self.verification_key.verify(data, signature)
     }
 }
 

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -143,6 +143,10 @@ impl Secret {
             identity: OnceCell::new(),
         })
     }
+
+    pub fn sign(&self, data: &[u8]) -> Signature {
+        self.signing_key.sign(data)
+    }
 }
 
 /// Public identity of a participant.
@@ -250,6 +254,16 @@ impl Identity {
         Self::new(verification_key, encryption_key, signature)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     }
+
+    pub fn verify_data(
+        &self,
+        data: &[u8],
+        signature_bytes: &[u8; 64],
+    ) -> Result<(), SignatureError> {
+        let signature = Signature::from(signature_bytes);
+
+        self.verification_key.verify(data, &signature)
+    }
 }
 
 // Need to implement `Hash` manually because `Signature` does not implement it
@@ -354,5 +368,31 @@ mod tests {
         let frost_id1 = id.to_frost_identifier();
         let frost_id2 = id.to_frost_identifier();
         assert_eq!(frost_id1, frost_id2);
+    }
+
+    #[test]
+    fn test_authenticated_data() {
+        let secret = Secret::random(thread_rng());
+        let id = secret.to_identity();
+
+        let data = b"hello world";
+        let signature = secret.sign(data);
+
+        id.verify_data(data, &signature.to_bytes())
+            .expect("verification failed");
+    }
+
+    #[test]
+    fn test_authenticated_data_bad_signature() {
+        let secret = Secret::random(thread_rng());
+        let id = secret.to_identity();
+
+        let data = b"hello world";
+        let fake_signature = [0u8; 64];
+
+        assert!(
+            id.verify_data(data, &fake_signature).is_err(),
+            "verification failed"
+        );
     }
 }


### PR DESCRIPTION
We will need to authenticate commitments are generated by the correct participants. This change adds methods to authenticate a buffer of data and verify a signature.