### PR TITLE
adds min_signers to PublicKeyPackage

### DIFF
--- a/src/keys.rs
+++ b/src/keys.rs
@@ -39,8 +39,8 @@ impl PublicKeyPackage {
         &self.frost_public_key_package
     }
 
-    pub fn min_signers(&self) -> &u64 {
-        &self.min_signers
+    pub fn min_signers(&self) -> u64 {
+        self.min_signers
     }
 
     pub fn serialize(&self) -> io::Result<Vec<u8>> {

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -7,17 +7,23 @@ use std::io;
 pub struct PublicKeyPackage {
     frost_public_key_package: FrostPublicKeyPackage,
     identities: Vec<Identity>,
+    min_signers: u64,
 }
 
 impl PublicKeyPackage {
     #[must_use]
-    pub fn from_frost<I>(frost_public_key_package: FrostPublicKeyPackage, identities: I) -> Self
+    pub fn from_frost<I>(
+        frost_public_key_package: FrostPublicKeyPackage,
+        identities: I,
+        min_signers: u64,
+    ) -> Self
     where
         I: IntoIterator<Item = Identity>,
     {
         Self {
             frost_public_key_package,
             identities: identities.into_iter().collect(),
+            min_signers,
         }
     }
 
@@ -31,6 +37,10 @@ impl PublicKeyPackage {
 
     pub fn frost_public_key_package(&self) -> &FrostPublicKeyPackage {
         &self.frost_public_key_package
+    }
+
+    pub fn min_signers(&self) -> &u64 {
+        &self.min_signers
     }
 
     pub fn serialize(&self) -> io::Result<Vec<u8>> {
@@ -58,6 +68,7 @@ impl PublicKeyPackage {
             let identity_bytes = identity.serialize();
             writer.write_all(&identity_bytes)?
         }
+        writer.write_all(&self.min_signers.to_le_bytes())?;
 
         Ok(())
     }
@@ -82,9 +93,14 @@ impl PublicKeyPackage {
             identities.push(Identity::deserialize_from(&mut reader)?);
         }
 
+        let mut min_signers = [0u8; 8];
+        reader.read_exact(&mut min_signers)?;
+        let min_signers = u64::from_le_bytes(min_signers);
+
         Ok(PublicKeyPackage {
             frost_public_key_package,
             identities,
+            min_signers,
         })
     }
 }


### PR DESCRIPTION
coordinators (and participants) may need to be able to persist and retrieve the minimum number of signers.

min_signers is part of each KeyPackage, but the coordinator may not have a KeyPackage

adds min_signers to our serialization of the PublicKeyPackage so that all participants and coordinators can access it