### PR TITLE
Update Rust to 1.76.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ blake3 = "1.5.0"
 chacha20 = "0.9.1"
 chacha20poly1305 = "0.10.1"
 ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
-once_cell = "1.8.0"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "311baf8865f6e21527d1f20750d8f2cf5c9e531a", features = ["frost", "frost-rerandomized"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.76.0"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -58,15 +58,15 @@ impl PublicKeyPackage {
         let public_key_package = self
             .frost_public_key_package
             .serialize()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+            .map_err(io::Error::other)?;
         let public_key_package_len = u32::try_from(public_key_package.len())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .map_err(io::Error::other)?
             .to_le_bytes();
         writer.write_all(&public_key_package_len)?;
         writer.write_all(&public_key_package)?;
 
         let identities_len = u32::try_from(self.identities.len())
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .map_err(io::Error::other)?
             .to_le_bytes();
         writer.write_all(&identities_len)?;
         for identity in &self.identities {
@@ -87,7 +87,7 @@ impl PublicKeyPackage {
         reader.read_exact(&mut frost_public_key_package)?;
         let frost_public_key_package =
             FrostPublicKeyPackage::deserialize(&frost_public_key_package)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                .map_err(io::Error::other)?;
 
         let mut identities_len = [0u8; 4];
         reader.read_exact(&mut identities_len)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![warn(missing_debug_implementations)]
 #![warn(pointer_structural_match)]
 #![warn(unreachable_pub)]
+#![warn(unused_crate_dependencies)]
 #![warn(unused_qualifications)]
 
 pub mod keys;

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -132,10 +132,7 @@ where
         writer.write_all(self.agreement_key.as_bytes())?;
 
         let encrypted_keys = self.encrypted_keys.as_ref();
-        let encrypted_keys_len: u32 = encrypted_keys
-            .len()
-            .try_into()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let encrypted_keys_len: u32 = encrypted_keys.len().try_into().map_err(io::Error::other)?;
         writer.write_all(&encrypted_keys_len.to_le_bytes())?;
 
         for key in encrypted_keys {
@@ -143,10 +140,7 @@ where
         }
 
         let ciphertext = self.ciphertext.as_ref();
-        let ciphertext_len: u32 = ciphertext
-            .len()
-            .try_into()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let ciphertext_len: u32 = ciphertext.len().try_into().map_err(io::Error::other)?;
         writer.write_all(&ciphertext_len.to_le_bytes())?;
         writer.write_all(ciphertext)
     }

--- a/src/signature_share.rs
+++ b/src/signature_share.rs
@@ -55,8 +55,8 @@ impl SignatureShare {
 
         let mut signature_share_bytes = [0u8; FROST_SIGNATURE_SHARE_LEN];
         reader.read_exact(&mut signature_share_bytes)?;
-        let frost_signature_share = FrostSignatureShare::deserialize(signature_share_bytes)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let frost_signature_share =
+            FrostSignatureShare::deserialize(signature_share_bytes).map_err(io::Error::other)?;
 
         Ok(SignatureShare {
             identity,

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -204,13 +204,11 @@ impl SigningCommitment {
 
         let mut hiding = [0u8; 32];
         reader.read_exact(&mut hiding)?;
-        let hiding = NonceCommitment::deserialize(hiding)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let hiding = NonceCommitment::deserialize(hiding).map_err(io::Error::other)?;
 
         let mut binding = [0u8; 32];
         reader.read_exact(&mut binding)?;
-        let binding = NonceCommitment::deserialize(binding)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let binding = NonceCommitment::deserialize(binding).map_err(io::Error::other)?;
 
         let raw_commitments = SigningCommitments::new(hiding, binding);
 
@@ -219,7 +217,7 @@ impl SigningCommitment {
         let checksum = Checksum::from_le_bytes(checksum);
 
         Self::from_raw_parts(identity, raw_commitments, checksum, signature)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 }
 


### PR DESCRIPTION
This reverts commit 705f29d4010567bba1333912de0036a730387bff, which was introduced to make this crate compatible with Rust 1.66. Now that the main ironfish repo is on Rust 1.76, we can update too and use some of the new features.