### PR TITLE
WIP wraps round1 package, computes checksum

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::participant::Identity;
+use siphasher::sip::SipHasher24;
+use std::borrow::Borrow;
+use std::error;
+use std::fmt;
+use std::hash::Hasher;
+
+pub const CHECKSUM_LEN: usize = 8;
+
+pub type Checksum = u64;
+
+#[derive(Clone, Debug)]
+pub struct ChecksumError;
+
+impl fmt::Display for ChecksumError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt("checksum doesn't match", f)
+    }
+}
+
+impl error::Error for ChecksumError {}
+
+#[must_use]
+pub fn input_checksum<I>(input_data: &[u8], signing_participants: &[I]) -> Checksum
+where
+    I: Borrow<Identity>,
+{
+    let mut signing_participants = signing_participants
+        .iter()
+        .map(Borrow::borrow)
+        .collect::<Vec<_>>();
+    signing_participants.sort_unstable();
+    signing_participants.dedup();
+
+    let mut hasher = SipHasher24::new();
+    hasher.write(input_data);
+
+    for id in signing_participants {
+        hasher.write(&id.serialize());
+    }
+
+    hasher.finish()
+}

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::borrow::Borrow;
+
+use rand_core::CryptoRng;
+use rand_core::RngCore;
+use reddsa::frost::redjubjub::Error;
+
+use crate::checksum::input_checksum;
+use crate::checksum::Checksum;
+use crate::checksum::ChecksumError;
+use crate::frost::keys::dkg::part1 as frost_part1;
+use crate::frost::keys::dkg::round1;
+use crate::participant::Identity;
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Package {
+    identity: Identity,
+    frost_package: round1::Package,
+    checksum: Checksum,
+}
+
+impl Package {
+    pub(crate) fn new(
+        identity: Identity,
+        signing_participants: &[Identity],
+        min_signers: u16,
+        frost_package: round1::Package,
+    ) -> Self {
+        let checksum = input_checksum(&min_signers.to_le_bytes(), signing_participants);
+
+        Package {
+            identity,
+            frost_package,
+            checksum,
+        }
+    }
+
+    pub fn verify_checksum<I>(
+        &self,
+        min_signers: u16,
+        signing_participants: &[I],
+    ) -> Result<(), ChecksumError>
+    where
+        I: Borrow<Identity>,
+    {
+        let computed_checksum = input_checksum(&min_signers.to_le_bytes(), signing_participants);
+        if self.checksum == computed_checksum {
+            Ok(())
+        } else {
+            Err(ChecksumError)
+        }
+    }
+
+    pub fn checksum(&self) -> Checksum {
+        self.checksum
+    }
+}
+
+pub fn part1<T: RngCore + CryptoRng>(
+    identity: Identity,
+    signing_participants: &[Identity],
+    min_signers: u16,
+    rng: T,
+) -> Result<Package, Error> {
+    let max_signers = signing_participants.len() as u16;
+
+    let (_, frost_package) = frost_part1(
+        identity.to_frost_identifier(),
+        max_signers,
+        min_signers,
+        rng,
+    )?;
+
+    Ok(Package::new(
+        identity,
+        signing_participants,
+        min_signers,
+        frost_package,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::{dkg::part1, participant::Secret};
+
+    #[test]
+    fn test_checksum_variation_with_min_signers() {
+        let mut rng = thread_rng();
+
+        let signing_participants = [
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let min_signers1: u16 = 2;
+        let min_signers2: u16 = 3;
+
+        let identity = &signing_participants[0];
+
+        let package_1 = part1(
+            identity.clone(),
+            &signing_participants,
+            min_signers1,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let package_2 = part1(
+            identity.clone(),
+            &signing_participants,
+            min_signers2,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        assert_ne!(package_1.checksum(), package_2.checksum());
+    }
+
+    #[test]
+    fn test_checksum_variation_with_signing_participants() {
+        let mut rng = thread_rng();
+
+        let identity = Secret::random(&mut rng).to_identity();
+
+        let signing_participants1 = [
+            identity.clone(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let signing_participants2 = [
+            identity.clone(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let min_signers: u16 = 2;
+
+        let package_1 = part1(
+            identity.clone(),
+            &signing_participants1,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let package_2 = part1(
+            identity.clone(),
+            &signing_participants2,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        assert_ne!(package_1.checksum(), package_2.checksum());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 #![warn(unused_crate_dependencies)]
 #![warn(unused_qualifications)]
 
+pub mod checksum;
+pub mod dkg;
 pub mod keys;
 pub mod multienc;
 pub mod nonces;


### PR DESCRIPTION
implements the same checksum as we used with SigningCommitments to verify that round1 packages are created with the same group parameters (min_signers, signing_participants)

- moves checksum to separate module
- defines Package struct to wrap the round1 Package from frost, includes the identity and checksum