### PR TITLE
defines checksum module

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::error;
+use std::fmt;
+
+pub(crate) const CHECKSUM_LEN: usize = 8;
+
+pub(crate) type Checksum = u64;
+
+#[derive(Clone, Debug)]
+pub struct ChecksumError;
+
+impl fmt::Display for ChecksumError {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt("checksum doesn't match", f)
+    }
+}
+
+impl error::Error for ChecksumError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(unused_crate_dependencies)]
 #![warn(unused_qualifications)]
 
+mod checksum;
 mod serde;
 
 pub mod keys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@
 #![warn(unused_crate_dependencies)]
 #![warn(unused_qualifications)]
 
-mod checksum;
 mod serde;
 
+pub mod checksum;
 pub mod keys;
 pub mod multienc;
 pub mod nonces;

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::checksum::Checksum;
+use crate::checksum::ChecksumError;
+use crate::checksum::CHECKSUM_LEN;
 use crate::frost::keys::SigningShare;
 use crate::frost::round1::NonceCommitment;
 use crate::frost::round1::SigningCommitments;
@@ -13,29 +16,12 @@ use crate::participant::SignatureError;
 use crate::participant::IDENTITY_LEN;
 use siphasher::sip::SipHasher24;
 use std::borrow::Borrow;
-use std::error;
-use std::fmt;
 use std::hash::Hasher;
 use std::io;
 
 const NONCE_COMMITMENT_LEN: usize = 32;
-const CHECKSUM_LEN: usize = 8;
 pub const AUTHENTICATED_DATA_LEN: usize = IDENTITY_LEN + NONCE_COMMITMENT_LEN * 2 + CHECKSUM_LEN;
 pub const SIGNING_COMMITMENT_LEN: usize = AUTHENTICATED_DATA_LEN + Signature::BYTE_SIZE;
-
-type Checksum = u64;
-
-#[derive(Clone, Debug)]
-pub struct ChecksumError;
-
-impl fmt::Display for ChecksumError {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt("checksum doesn't match", f)
-    }
-}
-
-impl error::Error for ChecksumError {}
 
 #[must_use]
 fn input_checksum<I>(transaction_hash: &[u8], signing_participants: &[I]) -> Checksum


### PR DESCRIPTION
supports reusing constants and types for checksums in multiple ironfish-frost modules

we will likely use checksums to verify data in multiple dkg rounds