### PR TITLE
WIP adds checksums to round1, round2 package structs

### DIFF
--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -151,7 +151,7 @@ mod round2 {
     use reddsa::frost::redjubjub::Error;
     use siphasher::sip::SipHasher24;
 
-    use crate::checksum::Checksum;
+    use crate::checksum::{Checksum, ChecksumError};
     use crate::frost::keys::dkg::round2 as frost_round2;
     use crate::participant::Identity;
 
@@ -199,6 +199,23 @@ mod round2 {
                 group_secret_key,
                 checksum,
             })
+        }
+
+        pub fn verify_checksum<P>(
+            &self,
+            packages: &[P],
+            group_secret_key: [u8; 32],
+        ) -> Result<(), ChecksumError>
+        where
+            P: Borrow<round1::Package>,
+        {
+            let computed_checksum =
+                input_checksum(packages, group_secret_key).map_err(|_| ChecksumError)?;
+            if self.checksum == computed_checksum {
+                Ok(())
+            } else {
+                Err(ChecksumError)
+            }
         }
 
         pub fn checksum(&self) -> Checksum {

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -20,7 +20,7 @@ mod round1 {
 
     use siphasher::sip::SipHasher24;
 
-    use crate::checksum::{Checksum, ChecksumError};
+    use crate::checksum::Checksum;
     use crate::frost::keys::dkg::round1 as frost_round1;
     use crate::participant::Identity;
 
@@ -69,22 +69,6 @@ mod round1 {
                 frost_package,
                 group_key_part,
                 checksum,
-            }
-        }
-
-        pub fn verify_checksum<I>(
-            &self,
-            min_signers: u16,
-            signing_participants: &[I],
-        ) -> Result<(), ChecksumError>
-        where
-            I: Borrow<Identity>,
-        {
-            let computed_checksum = input_checksum(min_signers, signing_participants);
-            if self.checksum == computed_checksum {
-                Ok(())
-            } else {
-                Err(ChecksumError)
             }
         }
 
@@ -151,7 +135,7 @@ mod round2 {
     use reddsa::frost::redjubjub::Error;
     use siphasher::sip::SipHasher24;
 
-    use crate::checksum::{Checksum, ChecksumError};
+    use crate::checksum::Checksum;
     use crate::frost::keys::dkg::round2 as frost_round2;
     use crate::participant::Identity;
 
@@ -199,23 +183,6 @@ mod round2 {
                 group_secret_key,
                 checksum,
             })
-        }
-
-        pub fn verify_checksum<P>(
-            &self,
-            packages: &[P],
-            group_secret_key: [u8; 32],
-        ) -> Result<(), ChecksumError>
-        where
-            P: Borrow<round1::Package>,
-        {
-            let computed_checksum =
-                input_checksum(packages, group_secret_key).map_err(|_| ChecksumError)?;
-            if self.checksum == computed_checksum {
-                Ok(())
-            } else {
-                Err(ChecksumError)
-            }
         }
 
         pub fn checksum(&self) -> Checksum {

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -1,0 +1,373 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::BTreeMap;
+
+use crate::frost::keys::dkg::part1 as frost_part1;
+use crate::frost::keys::dkg::part2 as frost_part2;
+use crate::frost::keys::dkg::round1 as frost_round1;
+use crate::participant::Identity;
+use rand_core::CryptoRng;
+use rand_core::RngCore;
+use reddsa::frost::redjubjub::Error;
+use reddsa::frost::redjubjub::Identifier;
+
+mod round1 {
+    use std::borrow::Borrow;
+    use std::cmp;
+    use std::hash::Hasher;
+
+    use siphasher::sip::SipHasher24;
+
+    use crate::checksum::{Checksum, ChecksumError};
+    use crate::frost::keys::dkg::round1 as frost_round1;
+    use crate::participant::Identity;
+
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct Package {
+        identity: Identity,
+        frost_package: frost_round1::Package,
+        checksum: Checksum,
+    }
+
+    #[must_use]
+    fn input_checksum<I>(min_signers: u16, signing_participants: &[I]) -> Checksum
+    where
+        I: Borrow<Identity>,
+    {
+        let mut signing_participants = signing_participants
+            .iter()
+            .map(Borrow::borrow)
+            .collect::<Vec<_>>();
+        signing_participants.sort_unstable();
+        signing_participants.dedup();
+
+        let mut hasher = SipHasher24::new();
+        hasher.write(&min_signers.to_le_bytes());
+
+        for id in signing_participants {
+            hasher.write(&id.serialize());
+        }
+
+        hasher.finish()
+    }
+
+    impl Package {
+        pub(crate) fn new(
+            identity: Identity,
+            signing_participants: &[Identity],
+            min_signers: u16,
+            frost_package: frost_round1::Package,
+        ) -> Self {
+            let checksum = input_checksum(min_signers, signing_participants);
+
+            Package {
+                identity,
+                frost_package,
+                checksum,
+            }
+        }
+
+        pub fn verify_checksum<I>(
+            &self,
+            min_signers: u16,
+            signing_participants: &[I],
+        ) -> Result<(), ChecksumError>
+        where
+            I: Borrow<Identity>,
+        {
+            let computed_checksum = input_checksum(min_signers, signing_participants);
+            if self.checksum == computed_checksum {
+                Ok(())
+            } else {
+                Err(ChecksumError)
+            }
+        }
+
+        pub fn identity(&self) -> &Identity {
+            &self.identity
+        }
+
+        pub fn frost_package(&self) -> &frost_round1::Package {
+            &self.frost_package
+        }
+
+        pub fn checksum(&self) -> Checksum {
+            self.checksum
+        }
+    }
+
+    impl Ord for Package {
+        #[inline]
+        fn cmp(&self, other: &Self) -> cmp::Ordering {
+            Ord::cmp(&self.identity(), &other.identity())
+        }
+    }
+
+    impl PartialOrd<Self> for Package {
+        #[inline]
+        fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+}
+
+pub fn part1<T: RngCore + CryptoRng>(
+    identity: Identity,
+    signing_participants: &[Identity],
+    min_signers: u16,
+    rng: T,
+) -> Result<(frost_round1::SecretPackage, round1::Package), Error> {
+    let max_signers = signing_participants.len() as u16;
+
+    let (secret_package, frost_package) = frost_part1(
+        identity.to_frost_identifier(),
+        max_signers,
+        min_signers,
+        rng,
+    )?;
+
+    Ok((
+        secret_package,
+        round1::Package::new(identity, signing_participants, min_signers, frost_package),
+    ))
+}
+
+mod round2 {
+    use std::borrow::Borrow;
+    use std::hash::Hasher;
+
+    use reddsa::frost::redjubjub::Error;
+    use siphasher::sip::SipHasher24;
+
+    use crate::checksum::Checksum;
+    use crate::frost::keys::dkg::round2 as frost_round2;
+    use crate::participant::Identity;
+
+    use super::round1;
+
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    pub struct Package {
+        identity: Identity,
+        frost_package: frost_round2::Package,
+        checksum: Checksum,
+    }
+
+    fn input_checksum<P>(packages: &[P]) -> Result<Checksum, Error>
+    where
+        P: Borrow<round1::Package>,
+    {
+        let mut packages = packages.iter().map(Borrow::borrow).collect::<Vec<_>>();
+        packages.sort_unstable();
+        packages.dedup();
+
+        let mut hasher = SipHasher24::new();
+
+        for package in packages {
+            hasher.write(&package.frost_package().serialize()?);
+        }
+
+        Ok(hasher.finish())
+    }
+
+    impl Package {
+        pub(crate) fn new(
+            identity: Identity,
+            round1_packages: &[round1::Package],
+            frost_package: frost_round2::Package,
+        ) -> Result<Self, Error> {
+            let checksum = input_checksum(round1_packages)?;
+
+            Ok(Package {
+                identity,
+                frost_package,
+                checksum,
+            })
+        }
+
+        pub fn checksum(&self) -> Checksum {
+            self.checksum
+        }
+    }
+}
+
+pub fn part2(
+    identity: Identity,
+    secret_package: frost_round1::SecretPackage,
+    round1_packages: &[round1::Package],
+) -> Result<Vec<round2::Package>, Error> {
+    let mut round1_frost_packages_map: BTreeMap<Identifier, frost_round1::Package> =
+        BTreeMap::new();
+
+    let mut identity_map: BTreeMap<Identifier, Identity> = BTreeMap::new();
+
+    for package in round1_packages {
+        if package.identity() == &identity {
+            continue;
+        }
+
+        round1_frost_packages_map.insert(
+            package.identity().to_frost_identifier(),
+            package.frost_package().clone(),
+        );
+
+        identity_map.insert(
+            package.identity().to_frost_identifier(),
+            package.identity().clone(),
+        );
+    }
+
+    let (_, round2_frost_packages_map) = frost_part2(secret_package, &round1_frost_packages_map)?;
+
+    let mut round2_packages: Vec<round2::Package> = Vec::new();
+
+    for (identifier, round2_frost_package) in round2_frost_packages_map.iter() {
+        let identity = identity_map
+            .remove(identifier)
+            .expect("part2 generated package for unknown identity");
+
+        let round2_package = round2::Package::new(
+            identity.clone(),
+            round1_packages,
+            round2_frost_package.clone(),
+        )?;
+
+        round2_packages.push(round2_package);
+    }
+
+    Ok(round2_packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::thread_rng;
+
+    use crate::dkg::part1;
+    use crate::dkg::part2;
+    use crate::participant::Secret;
+
+    #[test]
+    fn test_round1_checksum_variation_with_min_signers() {
+        let mut rng = thread_rng();
+
+        let signing_participants = [
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let min_signers1: u16 = 2;
+        let min_signers2: u16 = 3;
+
+        let identity = &signing_participants[0];
+
+        let (_, package_1) = part1(
+            identity.clone(),
+            &signing_participants,
+            min_signers1,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let (_, package_2) = part1(
+            identity.clone(),
+            &signing_participants,
+            min_signers2,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        assert_ne!(package_1.checksum(), package_2.checksum());
+    }
+
+    #[test]
+    fn test_round1_checksum_variation_with_signing_participants() {
+        let mut rng = thread_rng();
+
+        let identity = Secret::random(&mut rng).to_identity();
+
+        let signing_participants1 = [
+            identity.clone(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let signing_participants2 = [
+            identity.clone(),
+            Secret::random(&mut rng).to_identity(),
+            Secret::random(&mut rng).to_identity(),
+        ];
+
+        let min_signers: u16 = 2;
+
+        let (_, package1) = part1(
+            identity.clone(),
+            &signing_participants1,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let (_, package2) = part1(
+            identity.clone(),
+            &signing_participants2,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        assert_ne!(package1.checksum(), package2.checksum());
+    }
+
+    #[test]
+    fn test_round2_checksum_variation_with_packages() {
+        let mut rng = thread_rng();
+
+        let identity1 = Secret::random(&mut rng).to_identity();
+        let identity2 = Secret::random(&mut rng).to_identity();
+
+        let signing_participants = [identity1.clone(), identity2.clone()];
+
+        let min_signers: u16 = 2;
+
+        let (secret_package1, package1) = part1(
+            identity1.clone(),
+            &signing_participants,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let (secret_package2a, package2a) = part1(
+            identity2.clone(),
+            &signing_participants,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let (_, package2b) = part1(
+            identity2.clone(),
+            &signing_participants,
+            min_signers,
+            thread_rng(),
+        )
+        .expect("creating frost round1 package should not fail");
+
+        let round2_packages1 = part2(identity1, secret_package1, &[package1.clone(), package2a])
+            .expect("creating round2 packages should not fail");
+
+        assert_eq!(round2_packages1.len(), 1);
+
+        let round2_packages2 = part2(identity2, secret_package2a, &[package1.clone(), package2b])
+            .expect("creating round2 packages should not fail");
+
+        assert_eq!(round2_packages2.len(), 1);
+
+        assert_ne!(
+            round2_packages1[0].checksum(),
+            round2_packages2[0].checksum()
+        )
+    }
+}

--- a/src/dkg.rs
+++ b/src/dkg.rs
@@ -28,6 +28,7 @@ mod round1 {
     pub struct Package {
         identity: Identity,
         frost_package: frost_round1::Package,
+        group_key_part: [u8; 32],
         checksum: Checksum,
     }
 
@@ -58,6 +59,7 @@ mod round1 {
             identity: Identity,
             signing_participants: &[Identity],
             min_signers: u16,
+            group_key_part: [u8; 32],
             frost_package: frost_round1::Package,
         ) -> Self {
             let checksum = input_checksum(min_signers, signing_participants);
@@ -65,6 +67,7 @@ mod round1 {
             Package {
                 identity,
                 frost_package,
+                group_key_part,
                 checksum,
             }
         }
@@ -117,6 +120,7 @@ pub fn part1<T: RngCore + CryptoRng>(
     identity: Identity,
     signing_participants: &[Identity],
     min_signers: u16,
+    group_key_part: [u8; 32],
     rng: T,
 ) -> Result<(frost_round1::SecretPackage, round1::Package), Error> {
     let max_signers = signing_participants.len() as u16;
@@ -130,7 +134,13 @@ pub fn part1<T: RngCore + CryptoRng>(
 
     Ok((
         secret_package,
-        round1::Package::new(identity, signing_participants, min_signers, frost_package),
+        round1::Package::new(
+            identity,
+            signing_participants,
+            min_signers,
+            group_key_part,
+            frost_package,
+        ),
     ))
 }
 
@@ -241,6 +251,7 @@ pub fn part2(
 
 #[cfg(test)]
 mod tests {
+    use rand::random;
     use rand::thread_rng;
 
     use crate::dkg::part1;
@@ -250,6 +261,8 @@ mod tests {
     #[test]
     fn test_round1_checksum_stability() {
         let mut rng = thread_rng();
+
+        let group_key_part: [u8; 32] = random();
 
         let signing_participants = [
             Secret::random(&mut rng).to_identity(),
@@ -265,6 +278,7 @@ mod tests {
             identity.clone(),
             &signing_participants,
             min_signers1,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -273,6 +287,7 @@ mod tests {
             identity.clone(),
             &signing_participants,
             min_signers1,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -283,6 +298,8 @@ mod tests {
     #[test]
     fn test_round1_checksum_variation_with_min_signers() {
         let mut rng = thread_rng();
+
+        let group_key_part: [u8; 32] = random();
 
         let signing_participants = [
             Secret::random(&mut rng).to_identity(),
@@ -299,6 +316,7 @@ mod tests {
             identity.clone(),
             &signing_participants,
             min_signers1,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -307,6 +325,7 @@ mod tests {
             identity.clone(),
             &signing_participants,
             min_signers2,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -317,6 +336,8 @@ mod tests {
     #[test]
     fn test_round1_checksum_variation_with_signing_participants() {
         let mut rng = thread_rng();
+
+        let group_key_part: [u8; 32] = random();
 
         let identity = Secret::random(&mut rng).to_identity();
 
@@ -338,6 +359,7 @@ mod tests {
             identity.clone(),
             &signing_participants1,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -346,6 +368,7 @@ mod tests {
             identity.clone(),
             &signing_participants2,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -355,6 +378,8 @@ mod tests {
     #[test]
     fn test_round2_checksum_stability() {
         let mut rng = thread_rng();
+
+        let group_key_part: [u8; 32] = random();
 
         let identity1 = Secret::random(&mut rng).to_identity();
         let identity2 = Secret::random(&mut rng).to_identity();
@@ -367,6 +392,7 @@ mod tests {
             identity1.clone(),
             &signing_participants,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -375,6 +401,7 @@ mod tests {
             identity2.clone(),
             &signing_participants,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -407,6 +434,8 @@ mod tests {
     fn test_round2_checksum_variation_with_packages() {
         let mut rng = thread_rng();
 
+        let group_key_part: [u8; 32] = random();
+
         let identity1 = Secret::random(&mut rng).to_identity();
         let identity2 = Secret::random(&mut rng).to_identity();
 
@@ -418,6 +447,7 @@ mod tests {
             identity1.clone(),
             &signing_participants,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -426,6 +456,7 @@ mod tests {
             identity2.clone(),
             &signing_participants,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");
@@ -434,6 +465,7 @@ mod tests {
             identity2.clone(),
             &signing_participants,
             min_signers,
+            group_key_part,
             thread_rng(),
         )
         .expect("creating frost round1 package should not fail");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 mod serde;
 
 pub mod checksum;
+pub mod dkg;
 pub mod keys;
 pub mod multienc;
 pub mod nonces;


### PR DESCRIPTION
computes a checksum for packages in round1 output by hashing min_signers and signer identities

computes a checksum for packages in round2 output by hashing all round1 packages

wraps packages in new structs that include identity, frost package, and checksum

adds dkg module, round1 and round2 submodules