### PR TITLE
Add a function to perform the DKG round 1

### DIFF
--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::frost;
 use crate::frost::keys::dkg::round1::SecretPackage;
 use crate::frost::keys::VerifiableSecretSharingCommitment;
 use crate::frost::Field;
@@ -16,6 +17,7 @@ use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
+use std::fmt;
 use std::io;
 use std::mem;
 
@@ -121,10 +123,82 @@ pub fn import_secret_package(
     SerializableSecretPackage::deserialize_from(&serialized[..]).map(|pkg| pkg.into())
 }
 
+pub fn round1<'a, I, R: RngCore + CryptoRng>(
+    self_identity: &participant::Identity,
+    min_signers: u16,
+    participants: I,
+    mut csrng: R,
+) -> Result<(Vec<u8>, Vec<u8>), Error>
+where
+    I: IntoIterator<Item = &'a participant::Identity>,
+    R: RngCore + CryptoRng,
+{
+    // Remove duplicates from `participants` to ensure that `max_signers` is calculated correctly
+    let mut participants = participants.into_iter().collect::<Vec<_>>();
+    participants.sort_unstable();
+    participants.dedup();
+    let participants = participants;
+
+    if !participants.contains(&self_identity) {
+        return Err(Error::InvalidInput(
+            "participants must include self_identity",
+        ));
+    }
+
+    let max_signers = u16::try_from(participants.len())
+        .map_err(|_| Error::InvalidInput("too many participants"))?;
+
+    let (secret_package, public_package) = frost::keys::dkg::part1(
+        self_identity.to_frost_identifier(),
+        max_signers,
+        min_signers,
+        &mut csrng,
+    )
+    .map_err(Error::FrostError)?;
+
+    let encrypted_secret_package =
+        export_secret_package(&secret_package, self_identity, &mut csrng)
+            .map_err(Error::EncryptionError)?;
+    let public_package = public_package.serialize().map_err(Error::FrostError)?;
+
+    // TODO bind the min/max signers and the list of participants to the packages through
+    // checksumming
+    Ok((encrypted_secret_package, public_package))
+}
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidInput(&'static str),
+    FrostError(frost::Error),
+    EncryptionError(io::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::InvalidInput(e) => {
+                write!(f, "invalid input: ")?;
+                e.fmt(f)
+            }
+            Self::FrostError(e) => {
+                write!(f, "frost error: ")?;
+                e.fmt(f)
+            }
+            Self::EncryptionError(e) => {
+                write!(f, "encryption error: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::frost;
+    use crate::frost::keys::dkg::round1::Package;
     use crate::frost::keys::dkg::round1::SecretPackage;
     use rand::thread_rng;
 
@@ -163,5 +237,24 @@ mod tests {
         let imported = import_secret_package(&exported, &secret).expect("import failed");
 
         assert_eq!(secret_pkg, imported);
+    }
+
+    #[test]
+    fn round1() {
+        let secret = participant::Secret::random(thread_rng());
+        let identity1 = secret.to_identity();
+        let identity2 = participant::Secret::random(thread_rng()).to_identity();
+        let identity3 = participant::Secret::random(thread_rng()).to_identity();
+
+        let (secret_package, public_package) = super::round1(
+            &identity1,
+            2,
+            [&identity1, &identity2, &identity3],
+            thread_rng(),
+        )
+        .expect("round 1 failed");
+
+        import_secret_package(&secret_package, &secret).expect("secret package import failed");
+        Package::deserialize(&public_package).expect("public package deserialization failed");
     }
 }


### PR DESCRIPTION
The purpose of this function is to add all the Iron Fish specific functionality, like encryption and input checksumming.

For now this performs the same functionality as the function in https://github.com/iron-fish/ironfish/pull/4885.