### PR TITLE
defines round1 Package struct

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -5,9 +5,13 @@
 use std::error;
 use std::fmt;
 
+use siphasher::sip::SipHasher24;
+
 pub(crate) const CHECKSUM_LEN: usize = 8;
 
 pub(crate) type Checksum = u64;
+
+pub(crate) type ChecksumHasher = SipHasher24;
 
 #[derive(Clone, Debug)]
 pub struct ChecksumError;

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -15,8 +15,7 @@ pub const GROUP_SECRET_KEY_LEN: usize = 32;
 pub type GroupSecretKey = [u8; GROUP_SECRET_KEY_LEN];
 pub type GroupSecretKeyShardSerialization = [u8; GROUP_SECRET_KEY_LEN];
 
-#[derive(Clone)]
-#[allow(missing_debug_implementations)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct GroupSecretKeyShard {
     shard: [u8; GROUP_SECRET_KEY_LEN],
 }

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::checksum::Checksum;
+use crate::checksum::ChecksumHasher;
 use crate::checksum::CHECKSUM_LEN;
 use crate::frost;
 use crate::frost::keys::dkg::round1::Package as FrostPackage;
@@ -23,7 +24,6 @@ use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use siphasher::sip::SipHasher24;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::Hasher;
@@ -137,7 +137,7 @@ fn input_checksum<I>(min_signers: u16, signing_participants: &[I]) -> Checksum
 where
     I: Borrow<Identity>,
 {
-    let mut hasher = SipHasher24::new();
+    let mut hasher = ChecksumHasher::new();
 
     hasher.write(&min_signers.to_le_bytes());
 

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -159,7 +159,7 @@ where
 pub struct PublicPackage {
     identity: Identity,
     frost_package: Package,
-    group_secret_key_part: [u8; 32],
+    group_secret_key_shard: [u8; 32],
     checksum: Checksum,
 }
 
@@ -169,14 +169,14 @@ impl PublicPackage {
         min_signers: u16,
         signing_participants: &[Identity],
         frost_package: Package,
-        group_secret_key_part: [u8; 32],
+        group_secret_key_shard: [u8; 32],
     ) -> Self {
         let checksum = input_checksum(min_signers, signing_participants);
 
         PublicPackage {
             identity,
             frost_package,
-            group_secret_key_part,
+            group_secret_key_shard,
             checksum,
         }
     }
@@ -189,8 +189,8 @@ impl PublicPackage {
         &self.frost_package
     }
 
-    pub fn group_secret_key_part(&self) -> [u8; 32] {
-        self.group_secret_key_part
+    pub fn group_secret_key_shard(&self) -> [u8; 32] {
+        self.group_secret_key_shard
     }
 
     pub fn checksum(&self) -> Checksum {
@@ -207,7 +207,7 @@ impl PublicPackage {
         self.identity.serialize_into(&mut writer)?;
         let frost_package = self.frost_package.serialize().map_err(io::Error::other)?;
         write_variable_length_bytes(&mut writer, &frost_package)?;
-        writer.write_all(&self.group_secret_key_part)?;
+        writer.write_all(&self.group_secret_key_shard)?;
         writer.write_all(&self.checksum.to_le_bytes())?;
         Ok(())
     }
@@ -218,8 +218,8 @@ impl PublicPackage {
         let frost_package = read_variable_length_bytes(&mut reader)?;
         let frost_package = Package::deserialize(&frost_package).map_err(io::Error::other)?;
 
-        let mut group_secret_key_part = [0u8; 32];
-        reader.read_exact(&mut group_secret_key_part)?;
+        let mut group_secret_key_shard = [0u8; 32];
+        reader.read_exact(&mut group_secret_key_shard)?;
 
         let mut checksum = [0u8; CHECKSUM_LEN];
         reader.read_exact(&mut checksum)?;
@@ -228,7 +228,7 @@ impl PublicPackage {
         Ok(Self {
             identity,
             frost_package,
-            group_secret_key_part,
+            group_secret_key_shard,
             checksum,
         })
     }
@@ -436,14 +436,14 @@ mod tests {
         )
         .expect("dkg round1 failed");
 
-        let group_secret_key_part: [u8; 32] = random();
+        let group_secret_key_shard: [u8; 32] = random();
 
         let public_package = PublicPackage::new(
             identity.clone(),
             min_signers,
             &signing_participants,
             frost_package,
-            group_secret_key_part,
+            group_secret_key_shard,
         );
 
         let checksum = input_checksum(min_signers, &signing_participants);
@@ -475,14 +475,14 @@ mod tests {
         )
         .expect("dkg round1 failed");
 
-        let group_secret_key_part: [u8; 32] = random();
+        let group_secret_key_shard: [u8; 32] = random();
 
         let public_package = PublicPackage::new(
             identity.clone(),
             min_signers,
             &signing_participants,
             frost_package,
-            group_secret_key_part,
+            group_secret_key_shard,
         );
 
         let serialized = public_package.serialize();

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -164,13 +164,16 @@ pub struct PublicPackage {
 }
 
 impl PublicPackage {
-    pub(crate) fn new(
+    pub(crate) fn new<I>(
         identity: Identity,
         min_signers: u16,
-        signing_participants: &[Identity],
+        signing_participants: &[I],
         frost_package: Package,
         group_secret_key_shard: [u8; 32],
-    ) -> Self {
+    ) -> Self
+    where
+        I: Borrow<Identity>,
+    {
         let checksum = input_checksum(min_signers, signing_participants);
 
         PublicPackage {

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -164,7 +164,7 @@ pub struct PublicPackage {
 }
 
 impl PublicPackage {
-    pub fn new(
+    pub(crate) fn new(
         identity: Identity,
         min_signers: u16,
         signing_participants: &[Identity],

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -244,7 +244,7 @@ pub fn round1<'a, I, R: RngCore + CryptoRng>(
     min_signers: u16,
     participants: I,
     mut csrng: R,
-) -> Result<(Vec<u8>, Vec<u8>), Error>
+) -> Result<(Vec<u8>, PublicPackage), Error>
 where
     I: IntoIterator<Item = &'a Identity>,
     R: RngCore + CryptoRng,
@@ -285,7 +285,6 @@ where
         public_package,
         group_secret_key_shard,
     );
-    let public_package = public_package.serialize();
 
     Ok((encrypted_secret_package, public_package))
 }
@@ -511,7 +510,7 @@ mod tests {
         let identity2 = participant::Secret::random(thread_rng()).to_identity();
         let identity3 = participant::Secret::random(thread_rng()).to_identity();
 
-        let (secret_package, public_package) = super::round1(
+        let (secret_package, _) = super::round1(
             &identity1,
             2,
             [&identity1, &identity2, &identity3],
@@ -520,7 +519,5 @@ mod tests {
         .expect("round 1 failed");
 
         import_secret_package(&secret_package, &secret).expect("secret package import failed");
-        PublicPackage::deserialize_from(&public_package[..])
-            .expect("public package deserialization failed");
     }
 }

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -4,6 +4,7 @@
 
 use crate::checksum::Checksum;
 use crate::checksum::ChecksumError;
+use crate::checksum::ChecksumHasher;
 use crate::checksum::CHECKSUM_LEN;
 use crate::frost::keys::SigningShare;
 use crate::frost::round1::NonceCommitment;
@@ -14,7 +15,6 @@ use crate::participant::Secret;
 use crate::participant::Signature;
 use crate::participant::SignatureError;
 use crate::participant::IDENTITY_LEN;
-use siphasher::sip::SipHasher24;
 use std::borrow::Borrow;
 use std::hash::Hasher;
 use std::io;
@@ -35,7 +35,7 @@ where
     signing_participants.sort_unstable();
     signing_participants.dedup();
 
-    let mut hasher = SipHasher24::new();
+    let mut hasher = ChecksumHasher::new();
     hasher.write(transaction_hash);
 
     for id in signing_participants {


### PR DESCRIPTION
wraps frost-core round1 Package and includes identity, group_secret_key_part, and checksum

- the identity is the identity of the participant who generated the package.
- the group_secret_key_part is a 32 byte Sapling key that will be combined with group_secret_key_parts from other participants to generate the group_secret_key (used to derive nsk and ovk).
- the checksum is computed from the list of signer identities and min_signers that were used in round1.