### PR TITLE
Add functionality to serialize/deserialize/import/export the round2 SecretPackages

### DIFF
--- a/src/dkg/mod.rs
+++ b/src/dkg/mod.rs
@@ -3,3 +3,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 pub mod round1;
+pub mod round2;

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -1,0 +1,187 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use crate::frost::keys::dkg::round2::SecretPackage;
+use crate::frost::keys::VerifiableSecretSharingCommitment;
+use crate::frost::Field;
+use crate::frost::Identifier;
+use crate::frost::JubjubScalarField;
+use crate::multienc;
+use crate::multienc::MultiRecipientBlob;
+use crate::participant;
+use crate::serde::read_u16;
+use crate::serde::read_variable_length;
+use crate::serde::write_u16;
+use crate::serde::write_variable_length;
+use rand_core::CryptoRng;
+use rand_core::RngCore;
+use std::io;
+use std::mem;
+
+type Scalar = <JubjubScalarField as Field>::Scalar;
+
+/// Copy of the [`frost_core::dkg::round2::SecretPackage`] struct. Necessary to implement
+/// serialization for this struct. This must be kept in sync with the upstream version.
+struct SerializableSecretPackage {
+    identifier: Identifier,
+    commitment: VerifiableSecretSharingCommitment,
+    secret_share: Scalar,
+    min_signers: u16,
+    max_signers: u16,
+}
+
+impl From<SecretPackage> for SerializableSecretPackage {
+    #[inline]
+    fn from(pkg: SecretPackage) -> Self {
+        // SAFETY: The fields of `SecretPackage` and `SerializableSecretPackage` have the same
+        // size, alignment, and semantics
+        unsafe { mem::transmute(pkg) }
+    }
+}
+
+impl From<SerializableSecretPackage> for SecretPackage {
+    #[inline]
+    fn from(pkg: SerializableSecretPackage) -> Self {
+        // SAFETY: The fields of `SecretPackage` and `SerializableSecretPackage` have the same
+        // size, alignment, and semantics
+        unsafe { mem::transmute(pkg) }
+    }
+}
+
+impl SerializableSecretPackage {
+    fn serialize_into<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
+        writer.write_all(&self.identifier.serialize())?;
+        write_variable_length(&mut writer, self.commitment.serialize(), |writer, array| {
+            writer.write_all(&array)
+        })?;
+        writer.write_all(&self.secret_share.to_bytes())?;
+        write_u16(&mut writer, self.min_signers)?;
+        write_u16(&mut writer, self.max_signers)?;
+        Ok(())
+    }
+
+    fn deserialize_from<R: io::Read>(mut reader: R) -> io::Result<Self> {
+        let mut identifier = [0u8; 32];
+        reader.read_exact(&mut identifier)?;
+        let identifier = Identifier::deserialize(&identifier).map_err(io::Error::other)?;
+
+        let commitment = VerifiableSecretSharingCommitment::deserialize(read_variable_length(
+            &mut reader,
+            |reader| {
+                let mut array = [0u8; 32];
+                reader.read_exact(&mut array)?;
+                Ok(array)
+            },
+        )?)
+        .map_err(io::Error::other)?;
+
+        let mut scalar = [0u8; 32];
+        reader.read_exact(&mut scalar)?;
+        let scalar: Option<Scalar> = Scalar::from_bytes(&scalar).into();
+        let secret_share =
+            scalar.ok_or_else(|| io::Error::other("coefficients deserialization failed"))?;
+
+        let min_signers = read_u16(&mut reader)?;
+        let max_signers = read_u16(&mut reader)?;
+
+        Ok(Self {
+            identifier,
+            commitment,
+            secret_share,
+            min_signers,
+            max_signers,
+        })
+    }
+}
+
+pub fn export_secret_package<R: RngCore + CryptoRng>(
+    pkg: &SecretPackage,
+    identity: &participant::Identity,
+    csrng: R,
+) -> io::Result<Vec<u8>> {
+    let serializable = SerializableSecretPackage::from(pkg.clone());
+    if serializable.identifier != identity.to_frost_identifier() {
+        return Err(io::Error::other("identity mismatch"));
+    }
+    let mut serialized = Vec::new();
+    serializable.serialize_into(&mut serialized)?;
+    multienc::encrypt(&serialized, [identity], csrng).serialize()
+}
+
+pub fn import_secret_package(
+    exported: &[u8],
+    secret: &participant::Secret,
+) -> io::Result<SecretPackage> {
+    let exported = MultiRecipientBlob::deserialize_from(exported)?;
+    let serialized = multienc::decrypt(secret, &exported).map_err(io::Error::other)?;
+    SerializableSecretPackage::deserialize_from(&serialized[..]).map(|pkg| pkg.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost;
+    use rand::thread_rng;
+    use std::collections::BTreeMap;
+
+    fn create_round2_packages() -> (participant::Secret, SecretPackage) {
+        let mut secrets = Vec::new();
+        let mut secret_packages = Vec::new();
+        let mut public_packages = BTreeMap::new();
+
+        let min_signers = 5;
+        let max_signers = 10;
+
+        for _ in 0..max_signers {
+            let secret = participant::Secret::random(thread_rng());
+            let id = secret.to_identity().to_frost_identifier();
+            let (secret_pkg, public_pkg) =
+                frost::keys::dkg::part1(id, max_signers, min_signers, thread_rng())
+                    .expect("dkg round 1 failed");
+
+            secrets.push(secret);
+            secret_packages.push(secret_pkg);
+            public_packages.insert(id, public_pkg);
+        }
+
+        let secret = secrets[0].clone();
+        let id = secret.to_identity().to_frost_identifier();
+        let round1_secret_pkg = secret_packages[0].clone();
+        public_packages.remove(&id);
+
+        let (round2_secret_pkg, _round2_pkgs) =
+            frost::keys::dkg::part2(round1_secret_pkg, &public_packages)
+                .expect("dkg round 2 failed");
+
+        (secret, round2_secret_pkg)
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let (_secret, secret_pkg) = create_round2_packages();
+
+        let mut serialized = Vec::new();
+        SerializableSecretPackage::from(secret_pkg.clone())
+            .serialize_into(&mut serialized)
+            .expect("serialization failed");
+
+        let deserialized: SecretPackage =
+            SerializableSecretPackage::deserialize_from(&serialized[..])
+                .expect("deserialization failed")
+                .into();
+
+        assert_eq!(secret_pkg, deserialized);
+    }
+
+    #[test]
+    fn export_import() {
+        let (secret, secret_pkg) = create_round2_packages();
+
+        let exported = export_secret_package(&secret_pkg, &secret.to_identity(), thread_rng())
+            .expect("export failed");
+        let imported = import_secret_package(&exported, &secret).expect("import failed");
+
+        assert_eq!(secret_pkg, imported);
+    }
+}


### PR DESCRIPTION
This is similar to fc199fd419bd3b490e1e550dbdf99651bc3a25b1 and b6537a9c1db7e8c6c04fc8945cfa57cfb9294084, but for round2 instead of round1.