### PR TITLE
add dkg round2 function

### DIFF
--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -1,0 +1,37 @@
+use crate::checksum::ChecksumError;
+use crate::frost;
+use std::fmt;
+use std::io;
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidInput(&'static str),
+    FrostError(frost::Error),
+    EncryptionError(io::Error),
+    ChecksumError(ChecksumError),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::InvalidInput(e) => {
+                write!(f, "invalid input: ")?;
+                e.fmt(f)
+            }
+            Self::FrostError(e) => {
+                write!(f, "frost error: ")?;
+                e.fmt(f)
+            }
+            Self::EncryptionError(e) => {
+                write!(f, "encryption error: ")?;
+                e.fmt(f)
+            }
+            Self::ChecksumError(e) => {
+                write!(f, "checksum error: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}

--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use crate::checksum::ChecksumError;
 use crate::frost;
 use std::fmt;

--- a/src/dkg/mod.rs
+++ b/src/dkg/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+pub mod error;
 pub mod group_key;
 pub mod round1;
 pub mod round2;

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -25,7 +25,6 @@ use crate::serde::write_variable_length_bytes;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
 use std::borrow::Borrow;
-use std::cmp;
 use std::hash::Hasher;
 use std::io;
 use std::mem;
@@ -237,20 +236,6 @@ impl PublicPackage {
             group_secret_key_shard,
             checksum,
         })
-    }
-}
-
-impl Ord for PublicPackage {
-    #[inline]
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        Ord::cmp(&self.identity(), &other.identity())
-    }
-}
-
-impl PartialOrd<Self> for PublicPackage {
-    #[inline]
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -138,7 +138,7 @@ where
     R: RngCore + CryptoRng,
 {
     let mut round1_public_packages = round1_public_packages.into_iter().collect::<Vec<_>>();
-    round1_public_packages.sort_unstable();
+    round1_public_packages.sort_unstable_by(|a, b| a.identity().cmp(b.identity()));
     round1_public_packages.dedup();
     let round1_public_packages = round1_public_packages;
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::checksum::ChecksumError;
+use crate::frost;
+use crate::frost::keys::dkg::round1;
+use crate::frost::keys::dkg::round2::Package;
 use crate::frost::keys::dkg::round2::SecretPackage;
 use crate::frost::keys::VerifiableSecretSharingCommitment;
 use crate::frost::Field;
@@ -16,8 +20,13 @@ use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
+use std::collections::BTreeMap;
 use std::io;
 use std::mem;
+
+use super::error::Error;
+use super::group_key::GroupSecretKeyShard;
+use super::round1::PublicPackage;
 
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
@@ -118,9 +127,66 @@ pub fn import_secret_package(
     SerializableSecretPackage::deserialize_from(&serialized[..]).map(|pkg| pkg.into())
 }
 
+pub fn round2<'a, P, R: RngCore + CryptoRng>(
+    self_identity: &participant::Identity,
+    round1_secret_package: round1::SecretPackage,
+    round1_public_packages: P,
+    mut csrng: R,
+) -> Result<(Vec<u8>, BTreeMap<Identifier, Package>), Error>
+where
+    P: IntoIterator<Item = &'a PublicPackage>,
+    R: RngCore + CryptoRng,
+{
+    let mut round1_public_packages = round1_public_packages.into_iter().collect::<Vec<_>>();
+    round1_public_packages.sort_unstable();
+    round1_public_packages.dedup();
+    let round1_public_packages = round1_public_packages;
+
+    let self_public_package = *round1_public_packages
+        .iter()
+        .find(|&p| p.identity() == self_identity)
+        .expect("missing public package for self_identity");
+
+    let mut frost_packages: BTreeMap<Identifier, round1::Package> = BTreeMap::new();
+    let mut group_secret_key_shards: Vec<&GroupSecretKeyShard> = Vec::new();
+
+    for public_package in round1_public_packages {
+        if public_package.checksum() != self_public_package.checksum() {
+            return Err(Error::ChecksumError(ChecksumError));
+        }
+
+        group_secret_key_shards.push(public_package.group_secret_key_shard());
+
+        // self_public_package must be excluded from frost::keys::dkg::part2 inputs
+        if public_package.identity() == self_identity {
+            continue;
+        }
+
+        frost_packages.insert(
+            public_package.identity().to_frost_identifier(),
+            public_package.frost_package().clone(),
+        );
+    }
+
+    let (round2_secret_package, round2_packages) =
+        frost::keys::dkg::part2(round1_secret_package, &frost_packages)
+            .map_err(Error::FrostError)?;
+
+    let encrypted_secret_package =
+        export_secret_package(&round2_secret_package, self_identity, &mut csrng)
+            .map_err(Error::EncryptionError)?;
+
+    // TODO add group_secret_key to PublicPackage structs
+    // let group_secret_key = GroupSecretKeyShard::combine(group_secret_key_shards);
+
+    // TODO return round2::PublicPackage structs
+    Ok((encrypted_secret_package, round2_packages))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dkg::round1;
     use crate::frost;
     use rand::thread_rng;
     use std::collections::BTreeMap;
@@ -183,5 +249,51 @@ mod tests {
         let imported = import_secret_package(&exported, &secret).expect("import failed");
 
         assert_eq!(secret_pkg, imported);
+    }
+
+    #[test]
+    fn round2() {
+        let secret = participant::Secret::random(thread_rng());
+        let identity1 = secret.to_identity();
+        let identity2 = participant::Secret::random(thread_rng()).to_identity();
+        let identity3 = participant::Secret::random(thread_rng()).to_identity();
+
+        let (round1_secret_package, package1) = round1::round1(
+            &identity1,
+            2,
+            [&identity1, &identity2, &identity3],
+            thread_rng(),
+        )
+        .expect("round 1 failed");
+
+        let (_, package2) = round1::round1(
+            &identity2,
+            2,
+            [&identity1, &identity2, &identity3],
+            thread_rng(),
+        )
+        .expect("round 1 failed");
+
+        let (_, package3) = round1::round1(
+            &identity3,
+            2,
+            [&identity1, &identity2, &identity3],
+            thread_rng(),
+        )
+        .expect("round 1 failed");
+
+        let round1_secret_package = round1::import_secret_package(&round1_secret_package, &secret)
+            .expect("secret package import failed");
+
+        let (secret_package, _) = super::round2(
+            &identity1,
+            round1_secret_package,
+            [&package1, &package2, &package3],
+            thread_rng(),
+        )
+        .expect("round 2 failed");
+
+        import_secret_package(&secret_package, &secret)
+            .expect("round 2 secret package import failed");
     }
 }

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -138,7 +138,7 @@ where
     R: RngCore + CryptoRng,
 {
     let mut round1_public_packages = round1_public_packages.into_iter().collect::<Vec<_>>();
-    round1_public_packages.sort_unstable_by(|a, b| a.identity().cmp(b.identity()));
+    round1_public_packages.sort_unstable_by_key(|&p| p.identity());
     round1_public_packages.dedup();
     let round1_public_packages = round1_public_packages;
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -129,7 +129,7 @@ pub fn import_secret_package(
 
 pub fn round2<'a, P, R: RngCore + CryptoRng>(
     self_identity: &participant::Identity,
-    round1_secret_package: round1::SecretPackage,
+    round1_secret_package: &round1::SecretPackage,
     round1_public_packages: P,
     mut csrng: R,
 ) -> Result<(Vec<u8>, BTreeMap<Identifier, Package>), Error>
@@ -169,7 +169,7 @@ where
     }
 
     let (round2_secret_package, round2_packages) =
-        frost::keys::dkg::part2(round1_secret_package, &frost_packages)
+        frost::keys::dkg::part2(round1_secret_package.clone(), &frost_packages)
             .map_err(Error::FrostError)?;
 
     let encrypted_secret_package =
@@ -287,7 +287,7 @@ mod tests {
 
         let (secret_package, _) = super::round2(
             &identity1,
-            round1_secret_package,
+            &round1_secret_package,
             [&package1, &package2, &package3],
             thread_rng(),
         )


### PR DESCRIPTION
defines round2 to take a round1 SecretPackage and a vector of round1 PublicPackages and run round2 of DKG.

finds the PublicPackage corresponding to self_identity and uses it to verify the checksums contained in all of the other PublicPackages.

iterates over round1 PublicPackages to construct map from identifier to frost package required for frost part2 inputs and to collect group_secret_key_shards

moves 'Error' enum from round1 to separate error module to allow reuse across dkg rounds, adds ChecksumError to enum