### PR TITLE
change ChecksumError to enum

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -14,12 +14,22 @@ pub(crate) type Checksum = u64;
 pub(crate) type ChecksumHasher = SipHasher24;
 
 #[derive(Clone, Debug)]
-pub struct ChecksumError;
+pub enum ChecksumError {
+    SigningCommitmentError,
+    DkgPublicPackageError,
+}
 
 impl fmt::Display for ChecksumError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt("checksum doesn't match", f)
+        match self {
+            Self::SigningCommitmentError => {
+                fmt::Display::fmt("SigningCommitment checksum doesn't match", f)
+            }
+            Self::DkgPublicPackageError => {
+                fmt::Display::fmt("PublicPackage checksum doesn't match", f)
+            }
+        }
     }
 }
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -152,7 +152,7 @@ where
 
     for public_package in round1_public_packages {
         if public_package.checksum() != self_public_package.checksum() {
-            return Err(Error::ChecksumError(ChecksumError));
+            return Err(Error::ChecksumError(ChecksumError::DkgPublicPackageError));
         }
 
         group_secret_key_shards.push(public_package.group_secret_key_shard());

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -141,7 +141,7 @@ impl SigningCommitment {
         if self.checksum == computed_checksum {
             Ok(())
         } else {
-            Err(ChecksumError)
+            Err(ChecksumError::SigningCommitmentError)
         }
     }
 


### PR DESCRIPTION
provides more specific error types and error messages for ChecksumErrors

defines two enum values for ChecksumErrors: one for mismatches in SigningCommitments and one for mismatches in DKG PublicPackages