### PR TITLE
DKG round 2: perform better validation on the input packages

### DIFF
--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -9,7 +9,7 @@ use std::io;
 
 #[derive(Debug)]
 pub enum Error {
-    InvalidInput(&'static str),
+    InvalidInput(String),
     FrostError(frost::Error),
     EncryptionError(io::Error),
     ChecksumError(ChecksumError),

--- a/src/participant.rs
+++ b/src/participant.rs
@@ -11,6 +11,7 @@ use rand_core::CryptoRng;
 use rand_core::RngCore;
 use std::cell::OnceCell;
 use std::cmp;
+use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::io;
@@ -302,6 +303,15 @@ impl<'a> From<&'a Identity> for frost::Identifier {
     #[inline]
     fn from(identity: &Identity) -> frost::Identifier {
         identity.to_frost_identifier()
+    }
+}
+
+impl fmt::Display for Identity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.serialize() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
The round 2 function now makes sure that:
- the number of input public packages matches the number of max signers (as specified in the secret package)
- there's only one public package per identity (previously, you could add more than one package for `self_identity`)