### PR TITLE
no-std for dkg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 
 [features]
-default = ["dkg"]
+default = ["signing"]
 
 std = []
 signing = ["dep:blake3", "dep:rand_chacha", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 
 [features]
-default = ["signing"]
+default = ["dkg"]
 
 std = []
 signing = ["dep:blake3", "dep:rand_chacha", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ed25519-dalek = { version = "2.1.0", features = ["rand_core"] }
 rand_chacha = { version = "0.3.1", optional = true }
 rand_core = "0.6.4"
 reddsa = { git = "https://github.com/ZcashFoundation/reddsa.git", rev = "311baf8865f6e21527d1f20750d8f2cf5c9e531a", features = ["frost", "frost-rerandomized"] }
-siphasher = { version = "1.0.0", optional = true }
+siphasher = { version = "1.0.0", features =["serde_no_std"] }
 x25519-dalek = { version = "2.0.0", features = ["reusable_secrets", "static_secrets"] }
 
 [dev-dependencies]
@@ -27,5 +27,5 @@ rand = "0.8.5"
 default = ["dkg"]
 
 std = []
-signing = ["dep:blake3", "dep:rand_chacha", "dep:siphasher", "std"]
+signing = ["dep:blake3", "dep:rand_chacha", "std"]
 dkg = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 
 [features]
-default = ["std", "signing"]
+default = ["dkg"]
 
 std = []
 signing = ["dep:blake3", "dep:rand_chacha", "dep:siphasher", "std"]
-dkg = ["std", "signing"]
+dkg = []

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -4,22 +4,12 @@
 
 use core::fmt;
 
-#[cfg(feature = "std")]
 use siphasher::sip::SipHasher24;
-#[cfg(feature = "std")]
 pub(crate) type ChecksumHasher = SipHasher24;
-
-#[cfg(not(feature = "std"))]
-use core::hash::SipHasher;
-#[cfg(not(feature = "std"))]
-pub(crate) type ChecksumHasher = SipHasher;
-
 
 pub(crate) const CHECKSUM_LEN: usize = 8;
 
 pub(crate) type Checksum = u64;
-
-
 
 #[derive(Clone, Debug)]
 pub enum ChecksumError {

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -2,16 +2,24 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use std::error;
-use std::fmt;
+use core::fmt;
 
+#[cfg(feature = "std")]
 use siphasher::sip::SipHasher24;
+#[cfg(feature = "std")]
+pub(crate) type ChecksumHasher = SipHasher24;
+
+#[cfg(not(feature = "std"))]
+use core::hash::SipHasher;
+#[cfg(not(feature = "std"))]
+pub(crate) type ChecksumHasher = SipHasher;
+
 
 pub(crate) const CHECKSUM_LEN: usize = 8;
 
 pub(crate) type Checksum = u64;
 
-pub(crate) type ChecksumHasher = SipHasher24;
+
 
 #[derive(Clone, Debug)]
 pub enum ChecksumError {
@@ -33,4 +41,7 @@ impl fmt::Display for ChecksumError {
     }
 }
 
+#[cfg(feature = "std")]
+use std::error;
+#[cfg(feature = "std")]
 impl error::Error for ChecksumError {}

--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -8,11 +8,6 @@ use crate::io;
 use core::fmt;
 use core::fmt::Debug;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-
 #[derive(Debug)]
 pub enum Error {
     InvalidInput(String),

--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -4,17 +4,14 @@
 
 use crate::checksum::ChecksumError;
 use crate::frost;
+use crate::io;
 use core::fmt;
 use core::fmt::Debug;
-use crate::io;
-
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
-
-
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -10,7 +10,8 @@ use core::fmt::Debug;
 
 #[derive(Debug)]
 pub enum Error {
-    InvalidInput(String),
+    // TODO(jwp): potentially remove these to reduce binary size
+    InvalidInput(&'static str),
     FrostError(frost::Error),
     EncryptionError(io::Error),
     DecryptionError(io::Error),

--- a/src/dkg/error.rs
+++ b/src/dkg/error.rs
@@ -4,8 +4,17 @@
 
 use crate::checksum::ChecksumError;
 use crate::frost;
-use std::fmt;
-use std::io;
+use core::fmt;
+use core::fmt::Debug;
+use crate::io;
+
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
+
 
 #[derive(Debug)]
 pub enum Error {
@@ -21,26 +30,27 @@ impl fmt::Display for Error {
         match self {
             Self::InvalidInput(e) => {
                 write!(f, "invalid input: ")?;
-                e.fmt(f)
+                Debug::fmt(&e, f)
             }
             Self::FrostError(e) => {
                 write!(f, "frost error: ")?;
-                e.fmt(f)
+                Debug::fmt(&e, f)
             }
             Self::EncryptionError(e) => {
                 write!(f, "encryption error: ")?;
-                e.fmt(f)
+                Debug::fmt(&e, f)
             }
             Self::DecryptionError(e) => {
                 write!(f, "decryption error: ")?;
-                e.fmt(f)
+                Debug::fmt(&e, f)
             }
             Self::ChecksumError(e) => {
                 write!(f, "checksum error: ")?;
-                e.fmt(f)
+                Debug::fmt(&e, f)
             }
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -7,7 +7,13 @@ use crate::participant::Identity;
 use crate::participant::Secret;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use std::io;
+use crate::io;
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
 
 pub const GROUP_SECRET_KEY_LEN: usize = 32;
 

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -69,6 +69,7 @@ impl GroupSecretKeyShard {
         Ok(Self { shard })
     }
 
+    #[cfg(feature = "std")]
     pub fn export<'a, I, R>(&self, recipients: I, csrng: R) -> Vec<u8>
     where
         I: IntoIterator<Item = &'a Identity>,
@@ -78,6 +79,8 @@ impl GroupSecretKeyShard {
         multienc::encrypt(&self.shard, recipients, csrng)
     }
 
+
+    #[cfg(feature = "std")]
     pub fn import(secret: &Secret, exported: &[u8]) -> io::Result<Self> {
         let bytes = multienc::decrypt(secret, exported).map_err(io::Error::other)?;
 
@@ -169,6 +172,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn export_import() {
         let secrets = [
             Secret::random(thread_rng()),

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -9,11 +9,6 @@ use crate::participant::Secret;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 pub const GROUP_SECRET_KEY_LEN: usize = 32;
 
 pub type GroupSecretKey = [u8; GROUP_SECRET_KEY_LEN];

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -2,18 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+use crate::io;
 use crate::multienc;
 use crate::participant::Identity;
 use crate::participant::Secret;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use crate::io;
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
 
 pub const GROUP_SECRET_KEY_LEN: usize = 32;
 

--- a/src/dkg/group_key.rs
+++ b/src/dkg/group_key.rs
@@ -85,7 +85,7 @@ impl GroupSecretKeyShard {
     }
 
     pub fn import(secret: &Secret, exported: &[u8]) -> io::Result<Self> {
-        let bytes = multienc::decrypt(secret, &exported).map_err(io::Error::other)?;
+        let bytes = multienc::decrypt(secret, exported).map_err(io::Error::other)?;
 
         if bytes.len() != GROUP_SECRET_KEY_LEN {
             return Err(io::Error::other(

--- a/src/dkg/mod.rs
+++ b/src/dkg/mod.rs
@@ -1,9 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
+ #[cfg(feature = "std")]
 pub mod error;
 pub mod group_key;
+#[cfg(feature = "std")]
 pub mod round1;
+#[cfg(feature = "std")]
 pub mod round2;
+#[cfg(feature = "std")]
 pub mod round3;

--- a/src/dkg/mod.rs
+++ b/src/dkg/mod.rs
@@ -1,10 +1,8 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
- #[cfg(feature = "std")]
 pub mod error;
 pub mod group_key;
-#[cfg(feature = "std")]
 pub mod round1;
 #[cfg(feature = "std")]
 pub mod round2;

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -14,6 +14,7 @@ use crate::frost::keys::VerifiableSecretSharingCommitment;
 use crate::frost::Field;
 use crate::frost::Identifier;
 use crate::frost::JubjubScalarField;
+use crate::io;
 use crate::multienc;
 use crate::multienc::read_encrypted_blob;
 use crate::participant;
@@ -24,22 +25,19 @@ use crate::serde::read_variable_length_bytes;
 use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
+use core::borrow::Borrow;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use core::borrow::Borrow;
-use crate::io;
 
-use core::mem;
 use core::hash::Hasher;
-
+use core::mem;
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
 use alloc::string::ToString;
-
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
@@ -261,7 +259,7 @@ impl PublicPackage {
         self.identity.serialize_into(&mut writer)?;
         let frost_package = self.frost_package.serialize().map_err(io::Error::other)?;
         write_variable_length_bytes(&mut writer, &frost_package)?;
-        writer.write_all(&self.group_secret_key_shard_encrypted[..])?;
+        write_variable_length_bytes(&mut writer, &self.group_secret_key_shard_encrypted)?;
         writer.write_all(&self.checksum.to_le_bytes())?;
         Ok(())
     }
@@ -271,8 +269,7 @@ impl PublicPackage {
 
         let frost_package = read_variable_length_bytes(&mut reader)?;
         let frost_package = Package::deserialize(&frost_package).map_err(io::Error::other)?;
-
-        let group_secret_key_shard_encrypted = read_encrypted_blob(&mut reader)?;
+        let group_secret_key_shard_encrypted = read_variable_length_bytes(&mut reader)?;
 
         let mut checksum = [0u8; CHECKSUM_LEN];
         reader.read_exact(&mut checksum)?;
@@ -502,6 +499,13 @@ mod tests {
         let deserialized = PublicPackage::deserialize_from(&serialized[..])
             .expect("package deserialization failed");
 
+        assert_eq!(public_package.identity, deserialized.identity);
+        assert_eq!(public_package.checksum, deserialized.checksum);
+        assert_eq!(public_package.frost_package, deserialized.frost_package);
+        assert_eq!(
+            public_package.group_secret_key_shard_encrypted,
+            deserialized.group_secret_key_shard_encrypted
+        );
         assert_eq!(public_package, deserialized);
     }
 

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -19,7 +19,9 @@ use crate::multienc;
 use crate::participant;
 use crate::participant::Identity;
 use crate::serde::read_u16;
+#[cfg(feature = "std")]
 use crate::serde::read_variable_length;
+#[cfg(feature = "std")]
 use crate::serde::read_variable_length_bytes;
 use crate::serde::write_u16;
 use crate::serde::write_variable_length;

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -164,7 +164,7 @@ pub fn import_secret_package(
     exported: &[u8],
     secret: &participant::Secret,
 ) -> io::Result<SecretPackage> {
-    let serialized = multienc::decrypt(secret, &exported).map_err(io::Error::other)?;
+    let serialized = multienc::decrypt(secret, exported).map_err(io::Error::other)?;
     SerializableSecretPackage::deserialize_from(&serialized[..]).map(|pkg| pkg.into())
 }
 

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -31,13 +31,6 @@ use rand_core::RngCore;
 use core::hash::Hasher;
 use core::mem;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::string::ToString;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
 /// Copy of the [`frost_core::dkg::round1::SecretPackage`] struct. Necessary to implement

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -155,7 +155,7 @@ pub fn export_secret_package<R: RngCore + CryptoRng>(
 
     let mut serialized = Vec::new();
     serializable
-        .serialize_into(&mut serialized[..])
+        .serialize_into(&mut serialized)
         .expect("serialization failed");
     Ok(multienc::encrypt(&serialized, [identity], csrng))
 }
@@ -253,7 +253,7 @@ impl PublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf[..]).expect("serialization failed");
+        self.serialize_into(&mut buf).expect("serialization failed");
         buf
     }
 
@@ -352,7 +352,7 @@ mod tests {
 
         let mut serialized = Vec::new();
         SerializableSecretPackage::from(secret_pkg.clone())
-            .serialize_into(&mut serialized[..])
+            .serialize_into(&mut serialized)
             .expect("serialization failed");
 
         let deserialized: SecretPackage =

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -16,7 +16,6 @@ use crate::frost::Identifier;
 use crate::frost::JubjubScalarField;
 use crate::io;
 use crate::multienc;
-use crate::multienc::read_encrypted_blob;
 use crate::participant;
 use crate::participant::Identity;
 use crate::serde::read_u16;

--- a/src/dkg/round1.rs
+++ b/src/dkg/round1.rs
@@ -26,10 +26,20 @@ use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use std::borrow::Borrow;
-use std::hash::Hasher;
-use std::io;
-use std::mem;
+use core::borrow::Borrow;
+use crate::io;
+
+use core::mem;
+use core::hash::Hasher;
+
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
 
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
@@ -145,7 +155,7 @@ pub fn export_secret_package<R: RngCore + CryptoRng>(
 
     let mut serialized = Vec::new();
     serializable
-        .serialize_into(&mut serialized)
+        .serialize_into(&mut serialized[..])
         .expect("serialization failed");
     Ok(multienc::encrypt(&serialized, [identity], csrng))
 }
@@ -243,7 +253,7 @@ impl PublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf).expect("serialization failed");
+        self.serialize_into(&mut buf[..]).expect("serialization failed");
         buf
     }
 
@@ -342,7 +352,7 @@ mod tests {
 
         let mut serialized = Vec::new();
         SerializableSecretPackage::from(secret_pkg.clone())
-            .serialize_into(&mut serialized)
+            .serialize_into(&mut serialized[..])
             .expect("serialization failed");
 
         let deserialized: SecretPackage =

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -31,6 +31,8 @@ use core::borrow::Borrow;
 use crate::io;
 use core::mem;
 use core::hash::Hasher;
+use log::info;
+
 
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
@@ -156,7 +158,7 @@ pub fn export_secret_package<R: RngCore + CryptoRng>(
 
     let mut serialized = Vec::new();
     serializable
-        .serialize_into(&mut serialized[..])
+        .serialize_into(&mut serialized)
         .expect("serialization failed");
     Ok(multienc::encrypt(&serialized, [identity], csrng))
 }
@@ -234,7 +236,8 @@ impl PublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf[..]).expect("serialization failed");
+        self.serialize_into(&mut buf).expect("serialization failed");
+        info!("buf: {:?}", buf);
         buf
     }
 
@@ -318,7 +321,7 @@ impl CombinedPublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf[..]).expect("serialization failed");
+        self.serialize_into(&mut buf).expect("serialization failed");
         buf
     }
 
@@ -524,7 +527,7 @@ mod tests {
 
         let mut serialized = Vec::new();
         SerializableSecretPackage::from(secret_pkg.clone())
-            .serialize_into(&mut serialized[..])
+            .serialize_into(&mut serialized)
             .expect("serialization failed");
 
         let deserialized: SecretPackage =

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -27,11 +27,23 @@ use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use std::borrow::Borrow;
+use core::borrow::Borrow;
+use crate::io;
+use core::mem;
+use core::hash::Hasher;
+
+#[cfg(feature = "std")]
 use std::collections::BTreeMap;
-use std::hash::Hasher;
-use std::io;
-use std::mem;
+
+
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
+
 
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
@@ -144,7 +156,7 @@ pub fn export_secret_package<R: RngCore + CryptoRng>(
 
     let mut serialized = Vec::new();
     serializable
-        .serialize_into(&mut serialized)
+        .serialize_into(&mut serialized[..])
         .expect("serialization failed");
     Ok(multienc::encrypt(&serialized, [identity], csrng))
 }
@@ -222,7 +234,7 @@ impl PublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf).expect("serialization failed");
+        self.serialize_into(&mut buf[..]).expect("serialization failed");
         buf
     }
 
@@ -306,7 +318,7 @@ impl CombinedPublicPackage {
 
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
-        self.serialize_into(&mut buf).expect("serialization failed");
+        self.serialize_into(&mut buf[..]).expect("serialization failed");
         buf
     }
 
@@ -512,7 +524,7 @@ mod tests {
 
         let mut serialized = Vec::new();
         SerializableSecretPackage::from(secret_pkg.clone())
-            .serialize_into(&mut serialized)
+            .serialize_into(&mut serialized[..])
             .expect("serialization failed");
 
         let deserialized: SecretPackage =

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -16,6 +16,7 @@ use crate::frost::keys::VerifiableSecretSharingCommitment;
 use crate::frost::Field;
 use crate::frost::Identifier;
 use crate::frost::JubjubScalarField;
+use crate::io;
 use crate::multienc;
 use crate::participant;
 use crate::participant::Identity;
@@ -25,27 +26,22 @@ use crate::serde::read_variable_length_bytes;
 use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
+use core::borrow::Borrow;
+use core::hash::Hasher;
+use core::mem;
 use rand_core::CryptoRng;
 use rand_core::RngCore;
-use core::borrow::Borrow;
-use crate::io;
-use core::mem;
-use core::hash::Hasher;
-use log::info;
-
+// use log::info;
 
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
-
-
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
-
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
@@ -167,7 +163,7 @@ pub fn import_secret_package(
     exported: &[u8],
     secret: &participant::Secret,
 ) -> io::Result<SecretPackage> {
-    let serialized = multienc::decrypt(secret, &exported).map_err(io::Error::other)?;
+    let serialized = multienc::decrypt(secret, exported).map_err(io::Error::other)?;
     SerializableSecretPackage::deserialize_from(&serialized[..]).map(|pkg| pkg.into())
 }
 
@@ -237,7 +233,6 @@ impl PublicPackage {
     pub fn serialize(&self) -> Vec<u8> {
         let mut buf = Vec::new();
         self.serialize_into(&mut buf).expect("serialization failed");
-        info!("buf: {:?}", buf);
         buf
     }
 

--- a/src/dkg/round2.rs
+++ b/src/dkg/round2.rs
@@ -36,13 +36,6 @@ use rand_core::RngCore;
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 type Scalar = <JubjubScalarField as Field>::Scalar;
 
 /// Copy of the [`frost_core::dkg::round2::SecretPackage`] struct. Necessary to implement

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -21,7 +21,6 @@ use crate::serde::read_variable_length_bytes;
 use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
-use alloc::borrow::ToOwned;
 use core::borrow::Borrow;
 use reddsa::frost::redjubjub::VerifyingKey;
 
@@ -65,17 +64,6 @@ impl PublicKeyPackage {
         &self.identities[..]
     }
 
-    pub fn get_size(&self) -> Result<usize, io::Error> {
-        let pkp = self
-            .frost_public_key_package
-            .serialize()
-            .map_err(io::Error::other)?;
-        let identities = (self.identities()[0].serialize().len() + 2) * self.identities.len();
-        // 2 bytes for length
-        let min_signers = 2;
-        Ok(pkp.len() + identities + min_signers)
-    }
-
     pub fn verifying_key(&self) -> &VerifyingKey {
         self.frost_public_key_package.verifying_key()
     }
@@ -89,9 +77,8 @@ impl PublicKeyPackage {
     }
 
     pub fn serialize(&self) -> Vec<u8> {
-        let size = self.get_size().expect("serialization failed");
-        let mut bytes = Vec::with_capacity(size);
-        self.serialize_into(&mut bytes.as_mut_slice())
+        let mut bytes = Vec::new();
+        self.serialize_into(&mut bytes)
             .expect("serialization failed");
         bytes
     }

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -21,9 +21,24 @@ use crate::serde::write_u16;
 use crate::serde::write_variable_length;
 use crate::serde::write_variable_length_bytes;
 use reddsa::frost::redjubjub::VerifyingKey;
-use std::borrow::Borrow;
+use core::borrow::Borrow;
+use crate::io;
+
+#[cfg(feature = "std")]
 use std::collections::BTreeMap;
-use std::io;
+
+
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::collections::BTreeMap;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+
+
+
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct PublicKeyPackage {
@@ -72,7 +87,6 @@ impl PublicKeyPackage {
         bytes
     }
 
-    #[cfg(feature = "std")]
     pub fn serialize_into<W: io::Write>(&self, mut writer: W) -> io::Result<()> {
         let frost_public_key_package = self
             .frost_public_key_package
@@ -87,7 +101,6 @@ impl PublicKeyPackage {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     pub fn deserialize_from<R: io::Read>(mut reader: R) -> io::Result<Self> {
         let frost_public_key_package = read_variable_length_bytes(&mut reader)?;
         let frost_public_key_package =

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -27,15 +27,6 @@ use reddsa::frost::redjubjub::VerifyingKey;
 #[cfg(feature = "std")]
 use std::collections::BTreeMap;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap;
-#[cfg(not(feature = "std"))]
-use alloc::string::ToString;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub struct PublicKeyPackage {
     frost_public_key_package: FrostPublicKeyPackage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 
 mod serde;
 
-#[cfg(feature = "signing")]
 mod checksum;
 
 pub mod multienc;
@@ -37,6 +36,11 @@ mod io {
     pub(crate) use std::io::Result;
     pub(crate) use std::io::Write;
 }
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 mod io {
@@ -72,6 +76,13 @@ mod io {
             } else {
                 Err(Error)
             }
+        }
+
+        fn by_ref(&mut self) -> &mut Self
+        where
+            Self: Sized,
+        {
+            self
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod io {
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(feature = "dkg")]
+#[cfg(not(feature = "std"))]
 mod io {
     use core::cmp;
     use core::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,3 +147,20 @@ mod io {
         }
     }
 }
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+impl io::Write for Vec<u8> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod io {
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "dkg")]
 mod io {
     use core::cmp;
     use core::mem;
@@ -163,4 +163,3 @@ impl io::Write for Vec<u8> {
         Ok(())
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,6 @@ mod io {
 }
 
 #[cfg(not(feature = "std"))]
-#[macro_use]
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-
-#[cfg(not(feature = "std"))]
 mod io {
     use core::cmp;
     use core::mem;
@@ -145,21 +140,5 @@ mod io {
             *self = remaining;
             Ok(n)
         }
-    }
-}
-
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
-#[cfg(not(feature = "std"))]
-impl io::Write for Vec<u8> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.extend_from_slice(buf);
-        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,4 +163,3 @@ impl io::Write for Vec<u8> {
         Ok(())
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ mod io {
         }
     }
 
-    pub type Result<T> = core::result::Result<T, Error>;
+    pub(crate) type Result<T> = core::result::Result<T, Error>;
 
     pub trait Read {
         fn read(&mut self, buf: &mut [u8]) -> Result<usize>;

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -23,9 +23,9 @@ use x25519_dalek::ReusableSecret;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
 use crate::alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 pub const HEADER_SIZE: usize = 56;
 pub const KEY_SIZE: usize = 32;

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -20,13 +20,6 @@ use rand_core::RngCore;
 use x25519_dalek::PublicKey;
 use x25519_dalek::ReusableSecret;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use crate::alloc::borrow::ToOwned;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 pub const HEADER_SIZE: usize = 56;
 pub const KEY_SIZE: usize = 32;
 
@@ -36,6 +29,7 @@ pub const fn metadata_size(num_recipients: usize) -> usize {
     HEADER_SIZE + KEY_SIZE * num_recipients
 }
 
+#[cfg(feature = "std")]
 pub fn read_encrypted_blob<R>(reader: &mut R) -> Result<Vec<u8>, io::Error>
 where
     R: crate::io::Read,
@@ -59,7 +53,8 @@ where
     Ok(result)
 }
 
-#[must_use]
+// #[must_use]
+#[cfg(feature = "std")]
 pub fn encrypt<'a, I, R>(data: &[u8], recipients: I, csrng: R) -> Vec<u8>
 where
     I: IntoIterator<Item = &'a Identity>,
@@ -142,6 +137,7 @@ where
     Ok(())
 }
 
+#[cfg(feature = "std")]
 /// Decrypts data produced by [`encrypt`] or [`encrypt_in_place`] using one participant secret.
 ///
 /// This method expects the ciphertext and the metadata to be concatenated in one slice. Use
@@ -275,6 +271,7 @@ impl Header {
 }
 
 #[cfg(test)]
+#[cfg(feature = "std")]
 mod tests {
     mod detached {
         use crate::multienc::decrypt;

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -43,17 +43,17 @@ where
     let mut result = Vec::new();
 
     let mut header_bytes = [0u8; HEADER_SIZE];
-    reader.read(&mut header_bytes)?;
+    reader.read_exact(&mut header_bytes)?;
     let header: Header = Header::deserialize_from(&header_bytes[..])?;
 
     for _ in 0..header.num_recipients {
         let mut key_bytes = vec![0u8; KEY_SIZE];
-        reader.read(&mut key_bytes)?;
+        reader.read_exact(&mut key_bytes)?;
         result.extend(key_bytes);
     }
 
     let mut data_bytes = vec![0u8; header.data_len];
-    reader.read(&mut data_bytes)?;
+    reader.read_exact(&mut data_bytes)?;
     result.extend(data_bytes);
 
     Ok(result)

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -68,9 +68,9 @@ where
 {
     let recipients = recipients.into_iter();
     let metadata_len = metadata_size(recipients.len());
-    let mut result = Vec::with_capacity(metadata_len + data.len());
-    let (metadata, ciphertext) = result.split_at_mut(metadata_len);
+    let mut result = vec![0u8; metadata_len + data.len()];
 
+    let (metadata, ciphertext) = result.split_at_mut(metadata_len);
     ciphertext.copy_from_slice(data);
     encrypt_in_place(ciphertext, metadata, recipients, csrng).expect("failed to encrypt data");
 

--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -52,7 +52,7 @@ where
         result.extend(key_bytes);
     }
 
-    let mut data_bytes = vec![0u8; header.data_len as usize];
+    let mut data_bytes = vec![0u8; header.data_len];
     reader.read(&mut data_bytes)?;
     result.extend(data_bytes);
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -11,7 +11,6 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-
 #[inline]
 #[cfg(feature = "dkg")]
 pub(crate) fn write_u16<W: io::Write>(mut writer: W, value: u16) -> io::Result<()> {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,6 +6,12 @@
 
 use crate::io;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+
 #[inline]
 #[cfg(feature = "dkg")]
 pub(crate) fn write_u16<W: io::Write>(mut writer: W, value: u16) -> io::Result<()> {
@@ -91,7 +97,7 @@ where
 #[cfg(feature = "dkg")]
 pub(crate) fn read_variable_length_bytes<R: io::Read>(mut reader: R) -> io::Result<Vec<u8>> {
     let len = read_usize(&mut reader)?;
-    let mut bytes = vec![0u8; len];
+    let mut bytes = Vec::with_capacity(len);
     reader.read_exact(&mut bytes)?;
     Ok(bytes)
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -97,7 +97,7 @@ where
 #[cfg(feature = "dkg")]
 pub(crate) fn read_variable_length_bytes<R: io::Read>(mut reader: R) -> io::Result<Vec<u8>> {
     let len = read_usize(&mut reader)?;
-    let mut bytes = Vec::with_capacity(len);
+    let mut bytes = vec![0u8; len];
     reader.read_exact(&mut bytes)?;
     Ok(bytes)
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -6,11 +6,6 @@
 
 use crate::io;
 
-#[cfg(not(feature = "std"))]
-extern crate alloc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-
 #[inline]
 #[cfg(feature = "dkg")]
 pub(crate) fn write_u16<W: io::Write>(mut writer: W, value: u16) -> io::Result<()> {
@@ -77,8 +72,8 @@ pub(crate) fn read_usize<R: io::Read>(reader: R) -> io::Result<usize> {
     read_u32(reader).map(|value| value as usize)
 }
 
-#[inline]
-#[cfg(feature = "dkg")]
+// #[inline]
+#[cfg(feature = "std")]
 pub(crate) fn read_variable_length<R, F, T>(mut reader: R, f: F) -> io::Result<Vec<T>>
 where
     R: io::Read,
@@ -92,8 +87,8 @@ where
     Ok(items)
 }
 
-#[inline]
-#[cfg(feature = "dkg")]
+// #[inline]
+#[cfg(feature = "std")]
 pub(crate) fn read_variable_length_bytes<R: io::Read>(mut reader: R) -> io::Result<Vec<u8>> {
     let len = read_usize(&mut reader)?;
     let mut bytes = vec![0u8; len];
@@ -172,7 +167,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "dkg")]
+    #[cfg(feature = "std")]
     fn write_read_variable_length() {
         test_serde!(
             Vec::<u16>::new(),
@@ -194,7 +189,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "dkg")]
+    #[cfg(feature = "std")]
     fn write_read_variable_length_bytes() {
         test_serde!(
             &b""[..],

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -167,7 +167,7 @@ impl SigningCommitment {
 
     pub fn serialize(&self) -> [u8; SIGNING_COMMITMENT_LEN] {
         let mut bytes = [0u8; SIGNING_COMMITMENT_LEN];
-        self.serialize_into(&mut bytes[..])
+        self.serialize_into(&mut bytes)
             .expect("serialization failed");
         bytes
     }

--- a/src/signing_commitment.rs
+++ b/src/signing_commitment.rs
@@ -167,7 +167,7 @@ impl SigningCommitment {
 
     pub fn serialize(&self) -> [u8; SIGNING_COMMITMENT_LEN] {
         let mut bytes = [0u8; SIGNING_COMMITMENT_LEN];
-        self.serialize_into(&mut bytes)
+        self.serialize_into(&mut bytes[..])
             .expect("serialization failed");
         bytes
     }


### PR DESCRIPTION
Supports `no-std` for `dkg` module. Note that we have changed the `Cargo.toml` just for testing.

Most of the changes required were using `alloc` for `Vec` and some ser/de changes