### PR TITLE
adds error formatting for IronfishFrostError if std is enabled     

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ rand = "0.8.5"
 [features]
 default = ["signing"]
 
-std = []
+std = ["reddsa/std"]
 signing = ["dep:blake3", "dep:rand_chacha", "std"]
 dkg = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hex-literal = "0.4.1"
 rand = "0.8.5"
 
 [features]
-default = ["signing"]
+default = ["dkg", "std"]
 
 std = ["reddsa/std"]
 signing = ["dep:blake3", "dep:rand_chacha", "std"]

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -145,7 +145,7 @@ where
 
         #[cfg(not(feature = "std"))]
         return Err(IronfishFrostError::InvalidInput(
-            "incorrect number of round 1 public packages",
+            "incorrect number of round 1 public packages".to_string(),
         ));
     }
 
@@ -160,7 +160,7 @@ where
 
         #[cfg(not(feature = "std"))]
         return Err(IronfishFrostError::InvalidInput(
-            "incorrect number of round 2 public packages",
+            "incorrect number of round 2 public packages".to_string(),
         ));
     }
 
@@ -196,7 +196,7 @@ where
 
             #[cfg(not(feature = "std"))]
             return Err(IronfishFrostError::InvalidInput(
-                "multiple round 1 public packages provided for an identity",
+                "multiple round 1 public packages provided for an identity".to_string(),
             ));
         }
 
@@ -238,7 +238,7 @@ where
 
             #[cfg(not(feature = "std"))]
             return Err(IronfishFrostError::InvalidInput(
-                "round 2 public package does not have the correct recipient identity",
+                "round 2 public package does not have the correct recipient identity".to_string(),
             ));
         }
 

--- a/src/dkg/round3.rs
+++ b/src/dkg/round3.rs
@@ -32,6 +32,8 @@ extern crate alloc;
 #[cfg(not(feature = "std"))]
 use alloc::collections::BTreeMap;
 #[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -134,12 +136,32 @@ where
     // Ensure that the number of public packages provided matches max_signers
     let expected_round1_packages = max_signers as usize;
     if round1_public_packages.len() != expected_round1_packages {
-        return Err(IronfishFrostError::InvalidInput);
+        #[cfg(feature = "std")]
+        return Err(IronfishFrostError::InvalidInput(format!(
+            "expected {} round 1 public packages, got {}",
+            expected_round1_packages,
+            round1_public_packages.len()
+        )));
+
+        #[cfg(not(feature = "std"))]
+        return Err(IronfishFrostError::InvalidInput(
+            "incorrect number of round 1 public packages",
+        ));
     }
 
     let expected_round2_packages = expected_round1_packages.saturating_sub(1);
     if round2_public_packages.len() != expected_round2_packages {
-        return Err(IronfishFrostError::InvalidInput);
+        #[cfg(feature = "std")]
+        return Err(IronfishFrostError::InvalidInput(format!(
+            "expected {} round 2 public packages, got {}",
+            expected_round2_packages,
+            round2_public_packages.len()
+        )));
+
+        #[cfg(not(feature = "std"))]
+        return Err(IronfishFrostError::InvalidInput(
+            "incorrect number of round 2 public packages",
+        ));
     }
 
     let expected_round1_checksum = round1::input_checksum(
@@ -166,10 +188,21 @@ where
             .insert(frost_identifier, frost_package)
             .is_some()
         {
-            return Err(IronfishFrostError::InvalidInput);
+            #[cfg(feature = "std")]
+            return Err(IronfishFrostError::InvalidInput(format!(
+                "multiple round 1 public packages provided for identity {}",
+                public_package.identity()
+            )));
+
+            #[cfg(not(feature = "std"))]
+            return Err(IronfishFrostError::InvalidInput(
+                "multiple round 1 public packages provided for an identity",
+            ));
         }
 
-        let gsk_shard = public_package.group_secret_key_shard(secret)?;
+        let gsk_shard = public_package
+            .group_secret_key_shard(secret)
+            .map_err(IronfishFrostError::DecryptionError)?;
         gsk_shards.push(gsk_shard);
         identities.push(identity.clone());
     }
@@ -181,7 +214,9 @@ where
     // inputs
     round1_frost_packages
         .remove(&identity.to_frost_identifier())
-        .ok_or(IronfishFrostError::InvalidInput)?;
+        .ok_or(IronfishFrostError::InvalidInput(
+            "missing round 1 public package for own identity".to_string(),
+        ))?;
 
     let expected_round2_checksum =
         round2::input_checksum(round1_public_packages.iter().map(Borrow::borrow));
@@ -195,7 +230,16 @@ where
         }
 
         if !identity.eq(public_package.recipient_identity()) {
-            return Err(IronfishFrostError::InvalidInput);
+            #[cfg(feature = "std")]
+            return Err(IronfishFrostError::InvalidInput(format!(
+                "round 2 public package does not have the correct recipient identity {:?}",
+                public_package.recipient_identity().serialize()
+            )));
+
+            #[cfg(not(feature = "std"))]
+            return Err(IronfishFrostError::InvalidInput(
+                "round 2 public package does not have the correct recipient identity",
+            ));
         }
 
         let frost_identifier = public_package.sender_identity().to_frost_identifier();
@@ -205,7 +249,16 @@ where
             .insert(frost_identifier, frost_package)
             .is_some()
         {
-            return Err(IronfishFrostError::InvalidInput);
+            #[cfg(feature = "std")]
+            return Err(IronfishFrostError::InvalidInput(format!(
+                "multiple round 2 public packages provided for identity {}",
+                public_package.sender_identity(),
+            )));
+
+            #[cfg(not(feature = "std"))]
+            return Err(IronfishFrostError::InvalidInput(
+                "multiple round 2 public packages provided for an identity".to_string(),
+            ));
         }
     }
 
@@ -334,7 +387,7 @@ mod tests {
         );
 
         match result {
-            Err(IronfishFrostError::InvalidInput) => (),
+            Err(IronfishFrostError::InvalidInput(_)) => (),
             _ => panic!("dkg round3 should have failed with InvalidInput"),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,3 +36,41 @@ impl From<ed25519_dalek::SignatureError> for IronfishFrostError {
         IronfishFrostError::SignatureError(error)
     }
 }
+
+#[cfg(feature = "std")]
+use std::fmt;
+
+#[cfg(feature = "std")]
+impl fmt::Display for IronfishFrostError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::InvalidInput => {
+                write!(f, "invalid input")?;
+                Ok(())
+            }
+            Self::StdError => {
+                write!(f, "std error")?;
+                Ok(())
+            }
+            Self::FrostError(e) => {
+                write!(f, "frost error: ")?;
+                e.fmt(f)
+            }
+            Self::IoError(e) => {
+                write!(f, "io error: ")?;
+                e.fmt(f)
+            }
+            Self::SignatureError(e) => {
+                write!(f, "signature rror: ")?;
+                e.fmt(f)
+            }
+            Self::ChecksumError(e) => {
+                write!(f, "checksum error: ")?;
+                e.fmt(f)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IronfishFrostError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,11 +9,18 @@ use crate::io;
 
 use crate::checksum::ChecksumError;
 
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
 #[derive(Debug)]
 pub enum IronfishFrostError {
-    InvalidInput,
+    InvalidInput(String),
     StdError,
     IoError(io::Error),
+    DecryptionError(io::Error),
+    EncryptionError(io::Error),
     FrostError(FrostError<JubjubBlake2b512>),
     SignatureError(ed25519_dalek::SignatureError),
     ChecksumError(ChecksumError),
@@ -44,20 +51,28 @@ use std::fmt;
 impl fmt::Display for IronfishFrostError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::InvalidInput => {
-                write!(f, "invalid input")?;
-                Ok(())
+            Self::InvalidInput(e) => {
+                write!(f, "invalid input: ")?;
+                e.fmt(f)
             }
             Self::StdError => {
                 write!(f, "std error")?;
                 Ok(())
             }
-            Self::FrostError(e) => {
-                write!(f, "frost error: ")?;
-                e.fmt(f)
-            }
             Self::IoError(e) => {
                 write!(f, "io error: ")?;
+                e.fmt(f)
+            }
+            Self::DecryptionError(e) => {
+                write!(f, "decryption error: ")?;
+                e.fmt(f)
+            }
+            Self::EncryptionError(e) => {
+                write!(f, "encryption error: ")?;
+                e.fmt(f)
+            }
+            Self::FrostError(e) => {
+                write!(f, "frost error: ")?;
                 e.fmt(f)
             }
             Self::SignatureError(e) => {


### PR DESCRIPTION
allows us to display error details in ironfish repo
    
enables std for reddsa dependency if std is enabled

restores previous error types and formatting
    
brings back DecryptionError and EncryptionError type enums
    
adds string parameter back to InvalidInput, restores prior error message, and
adds error messages when std and string formatting not available