### PR TITLE
do not pre-allocate vector capacity in MultiRecipientBlob

### DIFF
--- a/src/multienc.rs
+++ b/src/multienc.rs
@@ -305,7 +305,7 @@ impl MultiRecipientBlob<Vec<EncryptedKey>, Vec<u8>> {
         reader.read_exact(&mut encrypted_keys_len)?;
         let encrypted_keys_len = u32::from_le_bytes(encrypted_keys_len) as usize;
 
-        let mut encrypted_keys = Vec::with_capacity(encrypted_keys_len);
+        let mut encrypted_keys = Vec::new();
         for _ in 0..encrypted_keys_len {
             let mut key = EncryptedKey::default();
             reader.read_exact(&mut key)?;


### PR DESCRIPTION
the value we read for 'encrypted_keys_len' may not be a reasonable size if the bytes we're reading from weren't encrypted using the old method

pre-allocating the vector to a random usize capacity may cause memory allocation errors